### PR TITLE
Bug Fix for issue #150 - child field is null

### DIFF
--- a/rolluptool/src/classes/LREngine.cls
+++ b/rolluptool/src/classes/LREngine.cls
@@ -260,12 +260,15 @@ public class LREngine {
                         Concatenator concatenator =
                             new Concatenator(rsf.operation == RollupOperation.Concatenate_Distinct, rsf.concatenateDelimiter);
                         for(SObject childDetailRecord : childDetailRecords) {
+                            String childFieldValue = String.valueOf(childDetailRecord.get(rsf.detail.getName()));
+                            if (childFieldValue != null) {
                             if (rsf.detail.getType() == Schema.DisplayType.MultiPicklist) {
-                                for (String mspValue : String.valueOf(childDetailRecord.get(rsf.detail.getName())).split(';')) {
+                                    for (String mspValue : childFieldValue.split(';')) {
                                     concatenator.add(mspValue);
                                 }
                             } else {
-                                concatenator.add(String.valueOf(childDetailRecord.get(rsf.detail.getName())));
+                                    concatenator.add(childFieldValue);
+                                }
                             }
                         }
                         String concatenatedValues = concatenator.toString();


### PR DESCRIPTION
If the child field is null, then the split throws an exception. 