### PR TITLE
Make Namespace-Agnostic

### DIFF
--- a/rolluptool/src/classes/RollupController.cls
+++ b/rolluptool/src/classes/RollupController.cls
@@ -123,10 +123,7 @@ public with sharing class RollupController
 		else
 		{
 			// Namespace?
-			Schema.DescribeSObjectResult describe = LookupRollupSummary__c.sObjectType.getDescribe();
-			String name = describe.getName();
-			String localName = describe.getLocalName();
-			String namespace = name.removeEnd(localName).removeEnd('__');					
+			String namespace = Utilities.namespace();
 			// Deploy generated code
 			return
 			 	'/**\n' +
@@ -164,10 +161,7 @@ public with sharing class RollupController
 		else
 		{
 			// Namespace?
-			Schema.DescribeSObjectResult describe = LookupRollupSummary__c.sObjectType.getDescribe();
-			String name = describe.getName();
-			String localName = describe.getLocalName();
-			String namespace = name.removeEnd(localName).removeEnd('__');					
+			String namespace = Utilities.namespace();
 			// Deploy generated code		
 			return 
 				'/**\n' +

--- a/rolluptool/src/classes/RollupControllerTest.cls
+++ b/rolluptool/src/classes/RollupControllerTest.cls
@@ -155,8 +155,8 @@ private with sharing class RollupControllerTest
 		// Assert initial state of controller when the trigger for the child object is deployed
 		RollupController controller = new RollupController(new ApexPages.StandardController( rollupSummary ));
 		System.assertEquals(false, controller.Deployed);
-		System.assertEquals('dlrs_ContactTrigger', controller.RollupTriggerName);
-		System.assertEquals('dlrs_ContactTest', controller.RollupTriggerTestName);
+		System.assertEquals(Utilities.componentPrefix() + 'ContactTrigger', controller.RollupTriggerName);
+		System.assertEquals(Utilities.componentPrefix() + 'ContactTest', controller.RollupTriggerTestName);
 		System.assertEquals(null, controller.RollupTrigger);
 		System.assertEquals(null, controller.RollupTriggerTest);
 		System.assertEquals(
@@ -166,7 +166,7 @@ private with sharing class RollupControllerTest
 				'trigger ' + controller.RollupTriggerName + ' on ' + rollupSummary.ChildObject__c + '\n' + 
 				'    (before delete, before insert, before update, after delete, after insert, after undelete, after update)\n'+ 
 				'{\n'+
-				'    dlrs.RollupService.triggerHandler();\n'+
+				'    ' + Utilities.classPrefix() + 'RollupService.triggerHandler();\n'+
 				'}\n', controller.getTriggerCode());
 		System.assertEquals(
 			 	'/**\n' +
@@ -178,7 +178,7 @@ private with sharing class RollupControllerTest
 				'    private static testmethod void testTrigger()\n' +
 				'    {\n' + 
 				'        // Force the ' + controller.RollupTriggerName + ' to be invoked, fails the test if org config or other Apex code prevents this.\n' +
-				'        dlrs.RollupService.testHandler(new ' + rollupSummary.ChildObject__c + '());\n' +
+				'        ' + Utilities.classPrefix() + 'RollupService.testHandler(new ' + rollupSummary.ChildObject__c + '());\n' +
 				'    }\n' +
 				'}', controller.getTriggerTestCode());
 		System.assertEquals(

--- a/rolluptool/src/classes/RollupServiceTest.cls
+++ b/rolluptool/src/classes/RollupServiceTest.cls
@@ -1035,22 +1035,29 @@ private with sharing class RollupServiceTest
 		if(!TestContext.isSupported())
 			return;
 
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Colours__c.getDescribe().getName();
+
 		// Create a picklist rollup
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Test Rollup';
-		rollupSummary.ParentObject__c = 'dlrs__LookupParent__c';
-		rollupSummary.ChildObject__c = 'dlrs__LookupChild__c';
-		rollupSummary.RelationShipField__c = 'dlrs__LookupParent__c';
-		rollupSummary.FieldToAggregate__c = 'dlrs__Color__c';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
 		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Concatenate.name();
-		rollupSummary.AggregateResultField__c = 'dlrs__Colours__c';
+		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.ConcatenateDelimiter__c = ';';
 		rollupSummary.Active__c = true;
-		rollupSummary.CalculationMode__c = 'Realtime';	
+		rollupSummary.CalculationMode__c = 'Realtime';
 		insert rollupSummary;
-		
+
 		// Insert parents
-		Schema.SObjectType parentType = Schema.getGlobalDescribe().get('dlrs__LookupParent__c');
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
 		SObject parentB = parentType.newSObject();
@@ -1059,35 +1066,34 @@ private with sharing class RollupServiceTest
 		parentC.put('Name', 'ParentC');
 		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
 		insert parents;
-		
+
 		// Insert children
-		Schema.SObjectType childType = Schema.getGlobalDescribe().get('dlrs__LookupChild__c');
 		List<SObject> children = new List<SObject>();
-		for(SObject parent : parents)		
+		for(SObject parent : parents)
 		{
 			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
-			child1.put('dlrs__LookupParent__c', parent.Id);
-			child1.put('dlrs__Color__c', 'Red');
-			children.add(child1);				
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 'Red');
+			children.add(child1);
 			SObject child2 = childType.newSObject();
-			child2.put('dlrs__LookupParent__c', parent.Id);
-			child2.put('dlrs__Color__c', 'Yellow');
-			children.add(child2);				
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 'Yellow');
+			children.add(child2);
 			if(name.equals('ParentA') || name.equals('ParentB'))
 			{
 				SObject child3 = childType.newSObject();
-				child3.put('dlrs__LookupParent__c', parent.Id);
-				child3.put('dlrs__Color__c', 'Blue');
-				children.add(child3);				
+				child3.put(relationshipField, parent.Id);
+				child3.put(aggregateField, 'Blue');
+				children.add(child3);
 			}
 		}
 		insert children;
-				
-		// Assert rollups 
-		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query('select id, dlrs__Colours__c from dlrs__LookupParent__c'));
-		System.assertEquals('Red;Yellow;Blue', (String) assertParents.get(parentA.id).get('dlrs__Colours__c'));
-		System.assertEquals('Red;Yellow;Blue', (String) assertParents.get(parentB.id).get('dlrs__Colours__c'));
-		System.assertEquals('Red;Yellow', (String) assertParents.get(parentC.id).get('dlrs__Colours__c'));		
+
+		// Assert rollups
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals('Red;Yellow;Blue', (String) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals('Red;Yellow;Blue', (String) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals('Red;Yellow', (String) assertParents.get(parentC.id).get(aggregateResultField));
 	}
 }

--- a/rolluptool/src/classes/RollupServiceTest2.cls
+++ b/rolluptool/src/classes/RollupServiceTest2.cls
@@ -207,27 +207,34 @@ private with sharing class RollupServiceTest2
 		accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
 		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));			
 	}
-	
+
 	private testmethod static void testScheduleItemsAndLogs()
 	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Total__c.getDescribe().getName();
+
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Test Rollup';
-		rollupSummary.ParentObject__c = 'dlrs__LookupParent__c';
-		rollupSummary.ChildObject__c = 'dlrs__LookupChild__c';
-		rollupSummary.RelationShipField__c = 'dlrs__LookupParent__c';
-		rollupSummary.FieldToAggregate__c = 'dlrs__Amount__c';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
 		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
-		rollupSummary.AggregateResultField__c = 'dlrs__Total__c';
+		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.Active__c = true;
-		rollupSummary.CalculationMode__c = 'Scheduled';	
+		rollupSummary.CalculationMode__c = 'Scheduled';
 		insert rollupSummary;
-		
+
 		// Insert parents
-		Schema.SObjectType parentType = Schema.getGlobalDescribe().get('dlrs__LookupParent__c');
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
 		SObject parentB = parentType.newSObject();
@@ -236,37 +243,36 @@ private with sharing class RollupServiceTest2
 		parentC.put('Name', 'ParentC');
 		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
 		insert parents;
-		
+
 		// Insert children
-		Schema.SObjectType childType = Schema.getGlobalDescribe().get('dlrs__LookupChild__c');
 		List<SObject> children = new List<SObject>();
-		for(SObject parent : parents)		
+		for(SObject parent : parents)
 		{
 			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
-			child1.put('dlrs__LookupParent__c', parent.Id);
-			child1.put('dlrs__Amount__c', 20);
-			children.add(child1);				
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 20);
+			children.add(child1);
 			SObject child2 = childType.newSObject();
-			child2.put('dlrs__LookupParent__c', parent.Id);
-			child2.put('dlrs__Amount__c', 20);
-			children.add(child2);				
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 20);
+			children.add(child2);
 			if(name.equals('ParentA') || name.equals('ParentB'))
 			{
 				SObject child3 = childType.newSObject();
-				child3.put('dlrs__LookupParent__c', parent.Id);
-				child3.put('dlrs__Amount__c', 2);
-				children.add(child3);				
+				child3.put(relationshipField, parent.Id);
+				child3.put(aggregateField, 2);
+				children.add(child3);
 			}
 		}
 		insert children;
-		
+
 		// Assert scheduled items and log records
 		System.assertEquals(3, [select id from LookupRollupSummaryScheduleItems__c].size());
 		System.assertEquals(0, [select id from LookupRollupSummaryLog__c].size());
-		
+
 		// Run rollup job
-		Test.startTest();		
+		Test.startTest();
 		RollupService.runJobToProcessScheduledItems();
 		try {
 			// Assert not able to run more than one scheduled job at a time
@@ -274,40 +280,47 @@ private with sharing class RollupServiceTest2
 			System.assert(false, 'Expected exception');
 		} catch(Exception e) {
 			System.assertEquals('A previous Declarative Rollup Summary scheduled job \'RollupJob\' is still running, this scheduled execution will not occur.', e.getMessage());
-		} 
+		}
 		Test.stopTest();
 		// Assert the selector now reports the job is no longer running
 		System.assertEquals(false, new AsyncApexJobsSelector().jobsExecuting(new Set<String> { 'RollupJob' }));
-		
+
 		// Assert scheduled items and log records
 		List<LookupRollupSummaryLog__c> logs = [select id, ParentId__c, ParentObject__c, ErrorMessage__c from LookupRollupSummaryLog__c];
 		System.assertEquals(parentC.Id, logs[0].ParentId__c);
-		System.assertEquals('dlrs__LookupParent__c', logs[0].ParentObject__c);
+		System.assertEquals(parentObjectName, logs[0].ParentObject__c);
 		System.assertEquals(1, logs.size());
-		System.assertEquals('The answer is not 42! : FIELD_CUSTOM_VALIDATION_EXCEPTION (dlrs__Total__c)', logs[0].ErrorMessage__c);		
+		System.assertEquals('The answer is not 42! : FIELD_CUSTOM_VALIDATION_EXCEPTION (' + aggregateResultField + ')', logs[0].ErrorMessage__c);
 		System.assertEquals(1, [select id from LookupRollupSummaryScheduleItems__c].size());
 	}
-	
+
 	private testmethod static void testScheduleItemsAndLogsCleanup()
 	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Total__c.getDescribe().getName();
 		
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Test Rollup';
-		rollupSummary.ParentObject__c = 'dlrs__LookupParent__c';
-		rollupSummary.ChildObject__c = 'dlrs__LookupChild__c';
-		rollupSummary.RelationShipField__c = 'dlrs__LookupParent__c';
-		rollupSummary.FieldToAggregate__c = 'dlrs__Amount__c';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
 		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
-		rollupSummary.AggregateResultField__c = 'dlrs__Total__c';
+		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.Active__c = true;
 		rollupSummary.CalculationMode__c = 'Scheduled';	
 		insert rollupSummary;
 		
 		// Insert parents
-		Schema.SObjectType parentType = Schema.getGlobalDescribe().get('dlrs__LookupParent__c');
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
 		SObject parentB = parentType.newSObject();
@@ -318,22 +331,21 @@ private with sharing class RollupServiceTest2
 		insert parents;
 		
 		// Insert children
-		Schema.SObjectType childType = Schema.getGlobalDescribe().get('dlrs__LookupChild__c');
 		List<SObject> children = new List<SObject>();
 		for(SObject parent : parents)		
 		{
 			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
-			child1.put('dlrs__LookupParent__c', parent.Id);
-			child1.put('dlrs__Amount__c', 20);
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 20);
 			children.add(child1);				
 			SObject child2 = childType.newSObject();
-			child2.put('dlrs__LookupParent__c', parent.Id);
-			child2.put('dlrs__Amount__c', 20);
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 20);
 			children.add(child2);				
 			SObject child3 = childType.newSObject();
-			child3.put('dlrs__LookupParent__c', parent.Id);
-			child3.put('dlrs__Amount__c', 2);
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField, 2);
 			children.add(child3);				
 		}
 		insert children;
@@ -345,8 +357,8 @@ private with sharing class RollupServiceTest2
 		// Insert dummy log record for Parent C (emulate position left from above test)
 		insert new LookupRollupSummaryLog__c(
 				ParentId__c = parentC.id,
-				ParentObject__c = 'dlrs__LookupParent__c',
-				ErrorMessage__c = 'The answer is not 42! : FIELD_CUSTOM_VALIDATION_EXCEPTION (dlrs__Total__c)'
+				ParentObject__c = parentObjectName,
+				ErrorMessage__c = 'The answer is not 42! : FIELD_CUSTOM_VALIDATION_EXCEPTION (' + aggregateResultField + ')'
 			);
 		
 		// Run rollup job
@@ -358,7 +370,7 @@ private with sharing class RollupServiceTest2
 		System.assertEquals(0, [select id, ParentId__c, ErrorMessage__c from LookupRollupSummaryLog__c].size());		
 		System.assertEquals(0, [select id from LookupRollupSummaryScheduleItems__c].size());
 	}
-	
+
 	/**
 	 * Test to reproduce issue raised here, https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/11 
 	 **/

--- a/rolluptool/src/classes/RollupServiceTest3.cls
+++ b/rolluptool/src/classes/RollupServiceTest3.cls
@@ -45,9 +45,16 @@ private with sharing class RollupServiceTest3
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Total__c.getDescribe().getName();
+
 		// Insert parents
-		Schema.SObjectType parentType = Schema.getGlobalDescribe().get('dlrs__LookupParent__c');
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
 		SObject parentB = parentType.newSObject();
@@ -56,86 +63,92 @@ private with sharing class RollupServiceTest3
 		parentC.put('Name', 'ParentC');
 		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
 		insert parents;
-		
+
 		// Insert children
-		Schema.SObjectType childType = Schema.getGlobalDescribe().get('dlrs__LookupChild__c');
 		List<SObject> children = new List<SObject>();
-		for(SObject parent : parents)		
+		for(SObject parent : parents)
 		{
 			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
-			child1.put('dlrs__LookupParent__c', parent.Id);
-			child1.put('dlrs__Amount__c', 20);
-			children.add(child1);				
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 20);
+			children.add(child1);
 			SObject child2 = childType.newSObject();
-			child2.put('dlrs__LookupParent__c', parent.Id);
-			child2.put('dlrs__Amount__c', 20);
-			children.add(child2);				
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 20);
+			children.add(child2);
 			if(name.equals('ParentA') || name.equals('ParentB'))
 			{
 				SObject child3 = childType.newSObject();
-				child3.put('dlrs__LookupParent__c', parent.Id);
-				child3.put('dlrs__Amount__c', 2);
-				children.add(child3);				
+				child3.put(relationshipField, parent.Id);
+				child3.put(aggregateField, 2);
+				children.add(child3);
 			}
 		}
 		insert children;
 
-		// Create rollup AFTER the data exists		
+		// Create rollup AFTER the data exists
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Test Rollup';
-		rollupSummary.ParentObject__c = 'dlrs__LookupParent__c';
-		rollupSummary.ChildObject__c = 'dlrs__LookupChild__c';
-		rollupSummary.RelationShipField__c = 'dlrs__LookupParent__c';
-		rollupSummary.FieldToAggregate__c = 'dlrs__Amount__c';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
 		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
-		rollupSummary.AggregateResultField__c = 'dlrs__Total__c';
+		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.Active__c = true;
-		rollupSummary.CalculationMode__c = 'Scheduled';	
+		rollupSummary.CalculationMode__c = 'Scheduled';
 		insert rollupSummary;
-		
+
 		// Run rollup calculate job
-		Test.startTest();		
+		Test.startTest();
 		Id jobId = RollupService.runJobToCalculate(rollupSummary.Id);
 		rollupSummary = [select Id, CalculateJobId__c from LookupRollupSummary__c where Id  = :rollupSummary.Id];
 		System.assertEquals(jobId, rollupSummary.CalculateJobId__c); // Assert job id captured
-		try { 
+		try {
 			// Assert not possible to start another
 			RollupService.runJobToCalculate(rollupSummary.Id);
 			System.assert(false, 'Expected an exception');
 		} catch (Exception e) {
 			System.assert(e.getMessage().equals('A calculate job for rollup \'Test Rollup\' is already executing. If you suspect it is not aleady running try clearing the Calculate Job Id field and try again.'));
-		}			 
+		}
 		Test.stopTest();
 		// Assert job id cleared
 		rollupSummary = [select Id, CalculateJobId__c from LookupRollupSummary__c where Id  = :rollupSummary.Id];
-		System.assertEquals(null, rollupSummary.CalculateJobId__c);  
+		System.assertEquals(null, rollupSummary.CalculateJobId__c); 
 
-		// This should not generate any schedule items		
+		// This should not generate any schedule items
 		System.assertEquals(0, [select id from LookupRollupSummaryScheduleItems__c].size());
-		
-		// Assert rollups 
-		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query('select id, dlrs__Total__c from dlrs__LookupParent__c'));
-		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get('dlrs__Total__c'));
-		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get('dlrs__Total__c'));
-		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get('dlrs__Total__c'));		
-		
+
+		// Assert rollups
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+
 		// Assert scheduled items and log records
 		List<LookupRollupSummaryLog__c> logs = [select id, ParentId__c, ParentObject__c, ErrorMessage__c from LookupRollupSummaryLog__c];
 		System.assertEquals(parentC.Id, logs[0].ParentId__c);
-		System.assertEquals('dlrs__LookupParent__c', logs[0].ParentObject__c);
+		System.assertEquals(parentObjectName, logs[0].ParentObject__c);
 		System.assertEquals(1, logs.size());
-		System.assertEquals('The answer is not 42! : FIELD_CUSTOM_VALIDATION_EXCEPTION (dlrs__Total__c)', logs[0].ErrorMessage__c);		
+		System.assertEquals('The answer is not 42! : FIELD_CUSTOM_VALIDATION_EXCEPTION (' + aggregateResultField + ')', logs[0].ErrorMessage__c);
 	}
 
 	private testmethod static void testCalculateJobNotActive()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Total__c.getDescribe().getName();
+
 		// Insert parents
-		Schema.SObjectType parentType = Schema.getGlobalDescribe().get('dlrs__LookupParent__c');
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
 		SObject parentB = parentType.newSObject();
@@ -144,77 +157,83 @@ private with sharing class RollupServiceTest3
 		parentC.put('Name', 'ParentC');
 		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
 		insert parents;
-		
+
 		// Insert children
-		Schema.SObjectType childType = Schema.getGlobalDescribe().get('dlrs__LookupChild__c');
 		List<SObject> children = new List<SObject>();
-		for(SObject parent : parents)		
+		for(SObject parent : parents)
 		{
 			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
-			child1.put('dlrs__LookupParent__c', parent.Id);
-			child1.put('dlrs__Amount__c', 20);
-			children.add(child1);				
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 20);
+			children.add(child1);
 			SObject child2 = childType.newSObject();
-			child2.put('dlrs__LookupParent__c', parent.Id);
-			child2.put('dlrs__Amount__c', 20);
-			children.add(child2);				
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 20);
+			children.add(child2);
 			if(name.equals('ParentA') || name.equals('ParentB'))
 			{
 				SObject child3 = childType.newSObject();
-				child3.put('dlrs__LookupParent__c', parent.Id);
-				child3.put('dlrs__Amount__c', 2);
-				children.add(child3);				
+				child3.put(relationshipField, parent.Id);
+				child3.put(aggregateField, 2);
+				children.add(child3);
 			}
 		}
 		insert children;
 
-		// Create rollup AFTER the data exists		
+		// Create rollup AFTER the data exists
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Test Rollup';
-		rollupSummary.ParentObject__c = 'dlrs__LookupParent__c';
-		rollupSummary.ChildObject__c = 'dlrs__LookupChild__c';
-		rollupSummary.RelationShipField__c = 'dlrs__LookupParent__c';
-		rollupSummary.FieldToAggregate__c = 'dlrs__Amount__c';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
 		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
-		rollupSummary.AggregateResultField__c = 'dlrs__Total__c';
+		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.Active__c = false;
-		rollupSummary.CalculationMode__c = 'Scheduled';	
+		rollupSummary.CalculationMode__c = 'Scheduled';
 		insert rollupSummary;
-		
+
 		// Run rollup calculate job
-		Test.startTest();		
-		try { 
+		Test.startTest();
+		try {
 			// Assert not possible to start another
 			RollupService.runJobToCalculate(rollupSummary.Id);
 			System.assert(false, 'Expected an exception');
 		} catch (Exception e) {
 			System.assert(e.getMessage().equals('The rollup must be Active before you can run a Calculate job.'));
-		}			 
+		}
 		Test.stopTest();
 	}
-	
+
 	private testmethod static void testDeveloperAPI()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
-		// Create rollup		
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Total__c.getDescribe().getName();
+
+		// Create rollup
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Test Rollup';
-		rollupSummary.ParentObject__c = 'dlrs__LookupParent__c';
-		rollupSummary.ChildObject__c = 'dlrs__LookupChild__c';
-		rollupSummary.RelationShipField__c = 'dlrs__LookupParent__c';
-		rollupSummary.FieldToAggregate__c = 'dlrs__Amount__c';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
 		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
-		rollupSummary.AggregateResultField__c = 'dlrs__Total__c';
+		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.Active__c = true;
-		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Developer.name();	
+		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Developer.name();
 		insert rollupSummary;
-		
+
 		// Insert parents
-		Schema.SObjectType parentType = Schema.getGlobalDescribe().get('dlrs__LookupParent__c');
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
 		SObject parentB = parentType.newSObject();
@@ -223,55 +242,53 @@ private with sharing class RollupServiceTest3
 		parentC.put('Name', 'ParentC');
 		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
 		insert parents;
-		
+
 		// Insert children
-		Schema.SObjectType childType = Schema.getGlobalDescribe().get('dlrs__LookupChild__c');
 		List<SObject> children = new List<SObject>();
-		for(SObject parent : parents)		
+		for(SObject parent : parents)
 		{
 			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
-			child1.put('dlrs__LookupParent__c', parent.Id);
-			child1.put('dlrs__Amount__c', 20);
-			children.add(child1);				
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 20);
+			children.add(child1);
 			SObject child2 = childType.newSObject();
-			child2.put('dlrs__LookupParent__c', parent.Id);
-			child2.put('dlrs__Amount__c', 20);
-			children.add(child2);				
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 20);
+			children.add(child2);
 			if(name.equals('ParentA') || name.equals('ParentB'))
 			{
 				SObject child3 = childType.newSObject();
-				child3.put('dlrs__LookupParent__c', parent.Id);
-				child3.put('dlrs__Amount__c', 2);
-				children.add(child3);				
+				child3.put(relationshipField, parent.Id);
+				child3.put(aggregateField, 2);
+				children.add(child3);
 			}
 		}
 		insert children;
-		
-		// Assert nothing has changed on db 
-		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query('select id, dlrs__Total__c from dlrs__LookupParent__c'));
-		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get('dlrs__Total__c'));
-		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get('dlrs__Total__c'));
-		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get('dlrs__Total__c'));		
-				
+
+		// Assert nothing has changed on db
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+
 		// Call developer API
 		List<SObject> masterRecords = RollupService.rollup(children);
 
-		// Assert nothing has changed on db 
-		assertParents = new Map<Id, SObject>(Database.query('select id, dlrs__Total__c from dlrs__LookupParent__c'));
-		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get('dlrs__Total__c'));
-		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get('dlrs__Total__c'));
-		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get('dlrs__Total__c'));		
-		
+		// Assert nothing has changed on db
+		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+
 		// Assert rollups produced
 		assertParents = new Map<Id, SObject>(masterRecords);
-		System.assertEquals(3, masterRecords.size()); 
-		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get('dlrs__Total__c'));
-		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get('dlrs__Total__c'));
-		System.assertEquals(40, (Decimal) assertParents.get(parentC.id).get('dlrs__Total__c'));		
-	}	
-	
-	
+		System.assertEquals(3, masterRecords.size());
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals(40, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+	}
+
 	/**
 	 * https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/23
 	 */
@@ -322,6 +339,7 @@ private with sharing class RollupServiceTest3
 	/**
 	 * https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/23
 	 */
+
 	private testmethod static void testDateRollupInsertConditionalChild()
 	{
 		// Test supported?
@@ -371,59 +389,65 @@ private with sharing class RollupServiceTest3
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Total__c.getDescribe().getName();
+
 		// Configure rollup
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Test Rollup';
-		rollupSummary.ParentObject__c = 'dlrs__LookupParent__c';
-		rollupSummary.ChildObject__c = 'dlrs__LookupChild__c';
-		rollupSummary.RelationShipField__c = 'dlrs__LookupParent__c';
-		rollupSummary.FieldToAggregate__c = 'dlrs__Amount__c';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
 		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
-		rollupSummary.AggregateResultField__c = 'dlrs__Total__c';
+		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.Active__c = true;
-		rollupSummary.CalculationMode__c = 'Realtime';	
+		rollupSummary.CalculationMode__c = 'Realtime';
 		insert rollupSummary;
-				
+
 		// Insert parents
-		Schema.SObjectType parentType = Schema.getGlobalDescribe().get('dlrs__LookupParent__c');
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
 		insert parentA;
-		
+
 		// Insert children
-		Schema.SObjectType childType = Schema.getGlobalDescribe().get('dlrs__LookupChild__c');
 		SObject child1 = childType.newSObject();
-		child1.put('dlrs__LookupParent__c', parentA.Id);
+		child1.put(relationshipField, parentA.Id);
 		insert child1;
-		
-		// Assert rollup		
-		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query('select id, dlrs__Total__c from dlrs__LookupParent__c'));
-		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get('dlrs__Total__c'));
-					
+
+		// Assert rollup
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
+
 		// Create test user
 		User testUser = null;
 		System.runAs ( new User(Id = UserInfo.getUserId()) ) {
- 			testUser = createUser();
+			testUser = createUser();
 		}
-		
+
 		// Test data insert children as new user (who cannot see the parent)
 		System.runAs(testUser)
 		{
 			// Ensure this user can read it (the Sharing setting for LookupParent__c is Public Read Only)
-			assertParents = new Map<Id, SObject>(Database.query('select id, dlrs__Total__c from dlrs__LookupParent__c'));
-			System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get('dlrs__Total__c'));
-			
+			assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+			System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
+
 			// Attempt to indirectly via rollup trigger to update parent record
-			child1.put('dlrs__Amount__c', 42);
+			child1.put(aggregateField, 42);
 			update child1;
 		}
-		
+
 		// Assert rollup
-		assertParents = new Map<Id, SObject>(Database.query('select id, dlrs__Total__c from dlrs__LookupParent__c'));
-		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get('dlrs__Total__c'));
+		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
 	}
-	
+
 	/**
 	 * Create test user
 	 **/

--- a/rolluptool/src/classes/RollupServiceTest3.cls
+++ b/rolluptool/src/classes/RollupServiceTest3.cls
@@ -441,11 +441,11 @@ private with sharing class RollupServiceTest3
 			insert testUser;
 			
 			// Assign permission sets
-			Set<String> psNames = new Set<String> { 'LookupRollupSummariesFull', 'LookupRollupSummariesTest' };
+			Set<String> psNames = new Set<String> { 'LookupRollupSummariesFull' };
 			List<PermissionSet> ps = [select Id from PermissionSet where Name in :psNames];
 			insert new List<PermissionSetAssignment> {
-				new PermissionSetAssignment(AssigneeId = testUser.Id, PermissionSetId = ps[0].Id),
-				new PermissionSetAssignment(AssigneeId = testUser.Id, PermissionSetId = ps[1].Id) };
+				new PermissionSetAssignment(AssigneeId = testUser.Id, PermissionSetId = ps[0].Id)
+			};
 		} catch (Exception e) {
 			return null;
 		}		

--- a/rolluptool/src/classes/RollupSummaries.cls
+++ b/rolluptool/src/classes/RollupSummaries.cls
@@ -236,13 +236,13 @@ public with sharing class RollupSummaries extends SObjectDomain
 	{
 		if(Test.isRunningTest() && lookupRollupSummary.ChildObject__c == 'Opportunity')
 			return 'RollupServiceTestTrigger';
-		else if(Test.isRunningTest() && lookupRollupSummary.ChildObject__c == 'dlrs__LookupChild__c')
+		else if(Test.isRunningTest() && lookupRollupSummary.ChildObject__c == LookupChild__c.sObjectType.getDescribe().getName())
 			return 'RollupServiceTest2Trigger';
 		else if(Test.isRunningTest() && lookupRollupSummary.ChildObject__c == 'Account')
 			return 'RollupServiceTest3Trigger';
 		return calculateComponentName(lookupRollupSummary.ChildObject__c, 'Trigger', APEXTRIGGER_NAME_LENGTH);
 	}
-	
+
 	/**
 	 * Apex test name for given lookup rollup summary
 	 **/
@@ -252,25 +252,27 @@ public with sharing class RollupSummaries extends SObjectDomain
 			return 'RollupSummariesTest';		
 		return calculateComponentName(lookupRollupSummary.ChildObject__c, 'Test', APEXCLASS_NAME_LENGTH);
 	}
-	
+
 	/**
 	 * Ensures the component name never exceeds the given maximum length but yet still remains unique
 	 **/
+	@TestVisible
 	private static String calculateComponentName(String childObjectName, String suffix, Integer maxComponentNameLength)
 	{
 		String trimmedObjectName = childObjectName.replace('__c', '').replace('__', '_');
-		String componentName = 'dlrs_' + trimmedObjectName + suffix;
+		String prefix = Utilities.componentPrefix();
+		String componentName = prefix + trimmedObjectName + suffix;
 		Integer componentNameLength = componentName.length();
 		if(componentNameLength > maxComponentNameLength) // Do we need to trim the trigger name?
 		{
 			Map<String, Schema.SObjectType> gd = Schema.getGlobalDescribe();
-			SObjectType childObjectType = gd.get(childObjectName);		
+			SObjectType childObjectType = gd.get(childObjectName);
 			String childObjectPrefix = childObjectType.getDescribe().getKeyPrefix(); // Key prefix will be used to make the trimmed name unique again
 			Integer overflowChars = componentNameLength - maxComponentNameLength; // How much do we need to trim the name by?
 			trimmedObjectName = trimmedObjectName.substring(0, trimmedObjectName.length() - overflowChars); // Trim the overflow characters from the name
 			trimmedObjectName = trimmedObjectName.substring(0, trimmedObjectName.length() - childObjectPrefix.length()); // Trim space for the prefix on the end
 			trimmedObjectName+= childObjectPrefix; // Add on the end the unique object prefix (to ensure the trimmed name is still unique)
-			componentName = 'dlrs_' + trimmedObjectName + suffix; 
+			componentName = prefix + trimmedObjectName + suffix;
 		}
 		return componentName;
 	}

--- a/rolluptool/src/classes/RollupSummariesTest.cls
+++ b/rolluptool/src/classes/RollupSummariesTest.cls
@@ -341,14 +341,19 @@ private with sharing class RollupSummariesTest
 		if(!TestContext.isSupported())
 			return;
 		
-		System.assertEquals('dlrs_ContactTrigger', RollupSummaries.makeTriggerName(new LookupRollupSummary__c(ChildObject__c = 'Contact')));		
-		System.assertEquals('dlrs_ContactTest', RollupSummaries.makeTriggerTestName(new LookupRollupSummary__c(ChildObject__c = 'Contact')));		
-		System.assertEquals('dlrs_pse_AssignmentTrigger', RollupSummaries.makeTriggerName(new LookupRollupSummary__c(ChildObject__c = 'pse__Assignment__c')));		
-		System.assertEquals('dlrs_pse_AssignmentTest', RollupSummaries.makeTriggerTestName(new LookupRollupSummary__c(ChildObject__c = 'pse__Assignment__c')));		
-		System.assertEquals('dlrs_MyCustomObjectTrigger', RollupSummaries.makeTriggerName(new LookupRollupSummary__c(ChildObject__c = 'MyCustomObject__c')));		
-		System.assertEquals('dlrs_MyCustomObjectTest', RollupSummaries.makeTriggerTestName(new LookupRollupSummary__c(ChildObject__c = 'MyCustomObject__c')));
-		System.assertEquals('dlrs_dlrs_LookupChildAReallyRea06Trigger', RollupSummaries.makeTriggerName(new LookupRollupSummary__c(ChildObject__c = 'dlrs__LookupChildAReallyReallyReallyBigBigName__c')));		
-		System.assertEquals('dlrs_dlrs_LookupChildAReallyRealla06Test', RollupSummaries.makeTriggerTestName(new LookupRollupSummary__c(ChildObject__c = 'dlrs__LookupChildAReallyReallyReallyBigBigName__c')));		
+		String componentPrefix = Utilities.componentPrefix();
+		String objectPrefix = Utilities.objectPrefix();
+		System.assertEquals(componentPrefix + 'ContactTrigger', RollupSummaries.makeTriggerName(new LookupRollupSummary__c(ChildObject__c = 'Contact')));
+		System.assertEquals(componentPrefix + 'ContactTest', RollupSummaries.makeTriggerTestName(new LookupRollupSummary__c(ChildObject__c = 'Contact')));
+		System.assertEquals(componentPrefix + 'pse_AssignmentTrigger', RollupSummaries.makeTriggerName(new LookupRollupSummary__c(ChildObject__c = 'pse__Assignment__c')));
+		System.assertEquals(componentPrefix + 'pse_AssignmentTest', RollupSummaries.makeTriggerTestName(new LookupRollupSummary__c(ChildObject__c = 'pse__Assignment__c')));
+		System.assertEquals(componentPrefix + 'MyCustomObjectTrigger', RollupSummaries.makeTriggerName(new LookupRollupSummary__c(ChildObject__c = 'MyCustomObject__c')));
+		System.assertEquals(componentPrefix + 'MyCustomObjectTest', RollupSummaries.makeTriggerTestName(new LookupRollupSummary__c(ChildObject__c = 'MyCustomObject__c')));
+
+		String dlrsKeyPrefix = DeclarativeLookupRollupSummaries__c.sObjectType.getDescribe().getKeyPrefix();
+		// Test RollupSummaries.calculateComponentName directly so we can override the maxComponentNameLength
+		System.assertEquals(componentPrefix + componentPrefix + 'DeclarativeLookupRollupSu' + dlrsKeyPrefix + 'Trigger', RollupSummaries.calculateComponentName(objectPrefix + 'DeclarativeLookupRollupSummaries__c', 'Trigger', 35 + 2 * componentPrefix.length()));
+		System.assertEquals(componentPrefix + componentPrefix + 'DeclarativeLookupRollupSumma' + dlrsKeyPrefix + 'Test', RollupSummaries.calculateComponentName(objectPrefix + 'DeclarativeLookupRollupSummaries__c', 'Test', 35 + 2 * componentPrefix.length()));
 	}
 	
 	private testmethod static void testRelationshipCriteriaFieldsValidationSingle()

--- a/rolluptool/src/classes/Utilities.cls
+++ b/rolluptool/src/classes/Utilities.cls
@@ -1,0 +1,40 @@
+public with sharing class Utilities {
+	/**
+	 * Get the namespace of this package
+	 **/
+	public static String namespace()
+	{
+		Schema.DescribeSObjectResult describe = LookupRollupSummary__c.sObjectType.getDescribe();
+		String name = describe.getName();
+		String localName = describe.getLocalName();
+		String namespace = name.removeEnd(localName).removeEnd('__');
+		return namespace;
+	}
+
+	/**
+	 * Get the component prefix based on the current namespace
+	 **/
+	public static String componentPrefix()
+	{
+		String namespace = namespace();
+		return String.isEmpty(namespace) ? '' : (namespace + '_');
+	}
+
+	/**
+	 * Get the class prefix based on the current namespace
+	 **/
+	public static String classPrefix()
+	{
+		String namespace = namespace();
+		return String.isEmpty(namespace) ? '' : (namespace + '.');
+	}
+
+	/**
+	 * Get the object prefix based on the current namespace
+	 **/
+	public static String objectPrefix()
+	{
+		String namespace = namespace();
+		return String.isEmpty(namespace) ? '' : (namespace + '__');
+	}
+}

--- a/rolluptool/src/classes/Utilities.cls-meta.xml
+++ b/rolluptool/src/classes/Utilities.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>33.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/rolluptool/src/package.xml
+++ b/rolluptool/src/package.xml
@@ -35,6 +35,7 @@
         <members>WelcomeControllerTest</members>
         <members>RollupActionCalculate</members>
         <members>RollupActionCalculateTest</members>
+        <members>Utilities</members>
         <name>ApexClass</name>
     </types>
     <types>


### PR DESCRIPTION
Update code to run in orgs with no namespace or a namespace other than
"dlrs" by determining the namespace at run-time.

*The change from #176 is included in this pull request as well to allow for all tests to pass successfully in any dev org.  I've tested in a dev org with no namespace and one with a namespace other than `dlrs`.*