### PR TITLE
Use Namespace In Remote Site Setting Name

### DIFF
--- a/rolluptool/src/classes/WelcomeController.cls
+++ b/rolluptool/src/classes/WelcomeController.cls
@@ -30,7 +30,9 @@
 public with sharing class WelcomeController {
 	
 	public String Host {get;set;}
-	
+
+	public String RemoteSiteName { get { return Utilities.componentPrefix() + 'mdapi'; } }
+
 	public String MetadataResponse {get;set;}
 	
 	public Boolean MetadataConnectionWarning {get;set;}
@@ -63,7 +65,7 @@ public with sharing class WelcomeController {
 		// Display the response from the client side Metadata API callout
 		if(metadataResponse.length()==0)
 		{
-			ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Info, 'Remote Site Setting dlrs_mdapi has been created.' ));
+			ApexPages.addMessage(new ApexPages.Message(ApexPages.Severity.Info, 'Remote Site Setting ' + RemoteSiteName + ' has been created.' ));
 			MetadataConnectionWarning = false;
 		}
 		else

--- a/rolluptool/src/pages/welcome.page
+++ b/rolluptool/src/pages/welcome.page
@@ -17,7 +17,7 @@ function createRemoteSite()
 			'<env:Body>' +
 				'<createMetadata xmlns="http://soap.sforce.com/2006/04/metadata">' + 
 					'<metadata xsi:type="RemoteSiteSetting">' + 
-						'<fullName>dlrs_mdapi</fullName>' + 
+						'<fullName>{!RemoteSiteName}</fullName>' +
 						'<description>Metadata API Remote Site Setting for Declarative Rollup Tool (DLRS)</description>' + 
 						'<disableProtocolSecurity>false</disableProtocolSecurity>' + 
 						'<isActive>true</isActive>' + 


### PR DESCRIPTION
Use the current namespace in the name of the Remote Site Setting record.

*This is useful if you have the managed package installed, and need to deploy the unpackaged code to the same org.*