### PR TITLE
Issue #196 - Add support for specifying CalculationMode in developer API

### DIFF
--- a/rolluptool/src/classes/RollupService.cls
+++ b/rolluptool/src/classes/RollupService.cls
@@ -170,6 +170,17 @@ global with sharing class RollupService
 	 **/ 
 	global static List<SObject> rollup(List<SObject> childRecords)
 	{
+		return rollup(childRecords, new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Developer });
+	}
+
+	/**
+	 * Developer API for the tool, executes Rollup Summmaries with specified Calculation Modes
+	 *
+	 * @param childRecords Child records being modified
+	 * @returns Array of master records containing the updated rollups, calling code must perform update DML operation
+	 **/ 
+	public static List<SObject> rollup(List<SObject> childRecords, List<RollupSummaries.CalculationMode> calculationModes)
+	{
 		// Anything to process?
 		if(childRecords==null || childRecords.size()==0)
 			return new List<SObject>();
@@ -179,7 +190,7 @@ global with sharing class RollupService
 		Schema.DescribeSObjectResult childRecordDescribe = childObjectType.getDescribe();		
 		List<LookupRollupSummary__c> lookups =
 			new RollupSummariesSelector().selectActiveByChildObject(
-				new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Developer }, 
+				calculationModes, 
 				new Set<String> { childRecordDescribe.getName() });
 		if(lookups.size()==0)
 			return new List<SObject>(); // Nothing to see here! :)

--- a/rolluptool/src/classes/RollupService.cls
+++ b/rolluptool/src/classes/RollupService.cls
@@ -174,6 +174,17 @@ global with sharing class RollupService
 	}
 
 	/**
+	 * Developer API for the tool, only executes Rollup Summmaries with Calculation Mode set to Realtime
+	 *
+	 * @param childRecords Child records being modified
+	 * @returns Array of master records containing the updated rollups, calling code must perform update DML operation
+	 **/ 
+	global static List<SObject> rollupRealtime(List<SObject> childRecords)
+	{
+		return rollup(childRecords, new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Realtime });
+	}
+
+	/**
 	 * Developer API for the tool, executes Rollup Summmaries with specified Calculation Modes
 	 *
 	 * @param childRecords Child records being modified

--- a/rolluptool/src/classes/RollupServiceTest3.cls
+++ b/rolluptool/src/classes/RollupServiceTest3.cls
@@ -285,6 +285,9 @@ private with sharing class RollupServiceTest3
 		Test.stopTest();
 	}
 
+	/**
+	 * Test Developer API with Developer and Scheduled rollups defined but CalculationMode of Developer only (default overload of rollup)
+	 **/
 	private testmethod static void testDeveloperAPI()
 	{
 		// Test supported?
@@ -296,21 +299,37 @@ private with sharing class RollupServiceTest3
 		String parentObjectName = parentType.getDescribe().getName();
 		String childObjectName = childType.getDescribe().getName();
 		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
-		String aggregateField = LookupChild__c.Amount__c.getDescribe().getName();
-		String aggregateResultField = LookupParent__c.Total__c.getDescribe().getName();
+		String aggregateFieldA = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultFieldA = LookupParent__c.Total__c.getDescribe().getName();
+		String aggregateFieldB = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateResultFieldB = LookupParent__c.Colours__c.getDescribe().getName();
 
 		// Create rollup
-		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
-		rollupSummary.Name = 'Test Rollup';
-		rollupSummary.ParentObject__c = parentObjectName;
-		rollupSummary.ChildObject__c = childObjectName;
-		rollupSummary.RelationShipField__c = relationshipField;
-		rollupSummary.FieldToAggregate__c = aggregateField;
-		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
-		rollupSummary.AggregateResultField__c = aggregateResultField;
-		rollupSummary.Active__c = true;
-		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Developer.name();
-		insert rollupSummary;
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup Sum';
+		rollupSummaryA.ParentObject__c = parentObjectName;
+		rollupSummaryA.ChildObject__c = childObjectName;
+		rollupSummaryA.RelationShipField__c = relationshipField;
+		rollupSummaryA.FieldToAggregate__c = aggregateFieldA;
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultFieldA;
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Developer.name();
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup Concat';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.FieldToAggregate__c = aggregateFieldB;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Concatenate.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultFieldB;
+		rollupSummaryB.ConcatenateDelimiter__c = ';';
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Scheduled.name();		
+
+		// Insert rollup definitions
+		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
 
 		// Insert parents
 		SObject parentA = parentType.newSObject();
@@ -329,43 +348,169 @@ private with sharing class RollupServiceTest3
 			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
 			child1.put(relationshipField, parent.Id);
-			child1.put(aggregateField, 20);
+			child1.put(aggregateFieldA, 20);
+			child1.put(aggregateFieldB, 'Red');
 			children.add(child1);
 			SObject child2 = childType.newSObject();
 			child2.put(relationshipField, parent.Id);
-			child2.put(aggregateField, 20);
+			child2.put(aggregateFieldA, 20);
+			child2.put(aggregateFieldB, 'Yellow');
 			children.add(child2);
 			if(name.equals('ParentA') || name.equals('ParentB'))
 			{
 				SObject child3 = childType.newSObject();
 				child3.put(relationshipField, parent.Id);
-				child3.put(aggregateField, 2);
+				child3.put(aggregateFieldA, 2);
+				child3.put(aggregateFieldB, 'Blue');
 				children.add(child3);
 			}
 		}
 		insert children;
 
 		// Assert nothing has changed on db
-		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
-		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
-		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
-		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultFieldA, aggregateResultFieldB, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultFieldB));
 
 		// Call developer API
 		List<SObject> masterRecords = RollupService.rollup(children);
 
 		// Assert nothing has changed on db
-		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
-		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
-		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
-		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultFieldA, aggregateResultFieldB, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultFieldB));
 
 		// Assert rollups produced
 		assertParents = new Map<Id, SObject>(masterRecords);
 		System.assertEquals(3, masterRecords.size());
-		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
-		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
-		System.assertEquals(40, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(40, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultFieldB));
+	}
+
+	/**
+	 * Test developer API with multiple Calculation Modes (Developer and Scheduled)
+	 **/
+	private testmethod static void testDeveloperAPIWithModes()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateFieldA = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultFieldA = LookupParent__c.Total__c.getDescribe().getName();
+		String aggregateFieldB = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateResultFieldB = LookupParent__c.Colours__c.getDescribe().getName();
+
+		// Create rollup
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup Sum';
+		rollupSummaryA.ParentObject__c = parentObjectName;
+		rollupSummaryA.ChildObject__c = childObjectName;
+		rollupSummaryA.RelationShipField__c = relationshipField;
+		rollupSummaryA.FieldToAggregate__c = aggregateFieldA;
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultFieldA;
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Developer.name();
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup Concat';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.FieldToAggregate__c = aggregateFieldB;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Concatenate.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultFieldB;
+		rollupSummaryB.ConcatenateDelimiter__c = ';';
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Scheduled.name();		
+
+		// Insert rollup definitions
+		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
+
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			String name = (String) parent.get('Name');
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateFieldA, 20);
+			child1.put(aggregateFieldB, 'Red');
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateFieldA, 20);
+			child2.put(aggregateFieldB, 'Yellow');
+			children.add(child2);
+			if(name.equals('ParentA') || name.equals('ParentB'))
+			{
+				SObject child3 = childType.newSObject();
+				child3.put(relationshipField, parent.Id);
+				child3.put(aggregateFieldA, 2);
+				child3.put(aggregateFieldB, 'Blue');
+				children.add(child3);
+			}
+		}
+		insert children;
+
+		// Assert nothing has changed on db
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultFieldA, aggregateResultFieldB, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultFieldB));
+
+		// Call developer API specifying Developer and Schedule modes
+		List<SObject> masterRecords = RollupService.rollup(children, new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Developer, RollupSummaries.CalculationMode.Scheduled });
+
+		// Assert nothing has changed on db
+		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultFieldA, aggregateResultFieldB, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultFieldB));
+
+		// Assert rollups produced
+		assertParents = new Map<Id, SObject>(masterRecords);
+		System.assertEquals(3, masterRecords.size());
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(40, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals('Red;Yellow;Blue', (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals('Red;Yellow;Blue', (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals('Red;Yellow', (String) assertParents.get(parentC.id).get(aggregateResultFieldB));		
 	}
 
 	/**

--- a/rolluptool/src/classes/RollupServiceTest3.cls
+++ b/rolluptool/src/classes/RollupServiceTest3.cls
@@ -514,6 +514,123 @@ private with sharing class RollupServiceTest3
 	}
 
 	/**
+	 * Test Developer API with Developer and Scheduled rollups defined but CalculationMode of Realtime only
+	 **/
+	private testmethod static void testDeveloperAPIRealtime()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		// Disable the LookupChild trigger for this test to defer rollup execution using Developer API
+		TestContext.LookupChildTestTriggerEnabled = false;		
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateFieldA = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultFieldA = LookupParent__c.Total__c.getDescribe().getName();
+		String aggregateFieldB = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateResultFieldB = LookupParent__c.Colours__c.getDescribe().getName();
+
+		// Create rollup
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup Sum';
+		rollupSummaryA.ParentObject__c = parentObjectName;
+		rollupSummaryA.ChildObject__c = childObjectName;
+		rollupSummaryA.RelationShipField__c = relationshipField;
+		rollupSummaryA.FieldToAggregate__c = aggregateFieldA;
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultFieldA;
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup Concat';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.FieldToAggregate__c = aggregateFieldB;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Concatenate.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultFieldB;
+		rollupSummaryB.ConcatenateDelimiter__c = ';';
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Developer.name();		
+
+		// Insert rollup definitions
+		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
+
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			String name = (String) parent.get('Name');
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateFieldA, 20);
+			child1.put(aggregateFieldB, 'Red');
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateFieldA, 20);
+			child2.put(aggregateFieldB, 'Yellow');
+			children.add(child2);
+			if(name.equals('ParentA') || name.equals('ParentB'))
+			{
+				SObject child3 = childType.newSObject();
+				child3.put(relationshipField, parent.Id);
+				child3.put(aggregateFieldA, 2);
+				child3.put(aggregateFieldB, 'Blue');
+				children.add(child3);
+			}
+		}
+		insert children;
+
+		// Assert nothing has changed on db
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultFieldA, aggregateResultFieldB, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultFieldB));
+
+		// Call developer API to force realtime rollups
+		List<SObject> masterRecords = RollupService.rollupRealtime(children);
+
+		// Assert nothing has changed on db
+		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultFieldA, aggregateResultFieldB, parentObjectName })));
+		System.assertEquals(null, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultFieldB));
+
+		// Assert rollups produced
+		assertParents = new Map<Id, SObject>(masterRecords);
+		System.assertEquals(3, masterRecords.size());
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultFieldA));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultFieldA));
+		System.assertEquals(40, (Decimal) assertParents.get(parentC.id).get(aggregateResultFieldA));
+		System.assertEquals(null, (String) assertParents.get(parentA.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultFieldB));
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultFieldB));		
+	}	
+
+	/**
 	 * https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/23
 	 */
 	private testmethod static void testDateRollupDeleteChild()

--- a/rolluptool/src/classes/TestContext.cls
+++ b/rolluptool/src/classes/TestContext.cls
@@ -31,6 +31,8 @@ public class TestContext
 	public static Boolean OpportunityTestTriggerEnabled = true;
 	
 	public static Boolean AccountTestTriggerEnabled = true;
+
+	public static Boolean LookupChildTestTriggerEnabled = true;	
 	
 	/**
 	 * Tests are only executed when the test trigger is present (not packaged)

--- a/rolluptool/src/permissionsets/LookupRollupSummariesReadOnly.permissionset
+++ b/rolluptool/src/permissionsets/LookupRollupSummariesReadOnly.permissionset
@@ -93,26 +93,6 @@
         <enabled>false</enabled>
     </classAccesses>
     <classAccesses>
-        <apexClass>SObjectDomain</apexClass>
-        <enabled>false</enabled>
-    </classAccesses>
-    <classAccesses>
-        <apexClass>SObjectDomainTest</apexClass>
-        <enabled>false</enabled>
-    </classAccesses>
-    <classAccesses>
-        <apexClass>SObjectSelector</apexClass>
-        <enabled>false</enabled>
-    </classAccesses>
-    <classAccesses>
-        <apexClass>SObjectSelectorTest</apexClass>
-        <enabled>false</enabled>
-    </classAccesses>
-    <classAccesses>
-        <apexClass>StringBuilder</apexClass>
-        <enabled>false</enabled>
-    </classAccesses>
-    <classAccesses>
         <apexClass>TestContext</apexClass>
         <enabled>false</enabled>
     </classAccesses>

--- a/rolluptool/src/triggers/RollupServiceTest2Trigger.trigger
+++ b/rolluptool/src/triggers/RollupServiceTest2Trigger.trigger
@@ -8,5 +8,6 @@
 trigger RollupServiceTest2Trigger on LookupChild__c
     (before delete, before insert, before update, after delete, after insert, after undelete, after update)
 {
-    RollupService.triggerHandler();
+	if(TestContext.LookupChildTestTriggerEnabled)
+    	RollupService.triggerHandler();
 }


### PR DESCRIPTION
This is not the original desired result of the issue which would be to completely separate the "When" (calculationmode) from the "What" (rollup definition).  After reviewing the code, a change of that nature would be fairly invasive and honestly and unfortunately, take more time than I have available right now. 

As a compromise, I've exposed a public method that allows the modes to be specified with the previously existing global overload maintaining backwards compat and only executing Developer mode rollups.  Since CalculationMode is a public enum in a public class, I was unable to make the new rollup overload global so calling this method does require that the code be installed and not the package.  An unfortunate side-effect.

I think the end goal here should be to separate the "when" and "what" concerns but hopefully this is acceptable approach for the time being.