### PR TITLE
Issue212 rollup summary validations

### DIFF
--- a/rolluptool/src/classes/RollupSummaries.cls
+++ b/rolluptool/src/classes/RollupSummaries.cls
@@ -85,8 +85,8 @@ public class RollupSummaries extends fflib_SObjectDomain
 	
 	/**
 	 * Validations for inserts and updates of records
-	 **/ 
-	public override void onValidate()
+	 **/ 	
+	private void validateCommon()
 	{
 		// Cache Apex Describes and calculate child object tigger names
 		Set<String> rollupTriggerNames = new Set<String>();
@@ -217,6 +217,24 @@ public class RollupSummaries extends fflib_SObjectDomain
 				lookupRollupSummary.addError(error(e.getMessage(), lookupRollupSummary));	
 			} 											
 		}
+	}
+
+	/**
+	 * Validations for inserts of records
+	 **/ 
+	public override void onValidate()
+	{
+		// invoke validation that should occur for insert & update		
+		validateCommon();
+	}
+
+	/**
+	 * Validations for updates of records
+	 **/ 
+	public override void onValidate(Map<Id,SObject> existingRecords)
+	{
+		// invoke validation that should occur for insert & update
+		validateCommon();
 	}
 
 	private static final String MSG_INVALID_CRITERIA = 'Relationship Criteria \'\'{0}\'\' is not valid, see SOQL documentation http://www.salesforce.com/us/developer/docs/soql_sosl/Content/sforce_api_calls_soql_select_conditionexpression.htm, error is \'\'{1}\'\'';

--- a/rolluptool/src/classes/RollupSummariesTest.cls
+++ b/rolluptool/src/classes/RollupSummariesTest.cls
@@ -88,7 +88,40 @@ private class RollupSummariesTest
 		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());	
 		System.assertEquals('Object does not exist.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(LookupRollupSummary__c.ChildObject__c, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field);		
-	}	
+	}
+
+	/**
+	 * Issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/212
+	 **/
+	private testmethod static void testUpdateBadChildBigName()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+		
+		String rsId = fflib_IDGenerator.generate(LookupRollupSummary__c.SObjectType);
+
+		LookupRollupSummary__c oldRollupSummary = new LookupRollupSummary__c(Id=rsId);
+		oldRollupSummary.Name = 'Max Birthday for Contacts related to an Account';
+		oldRollupSummary.ParentObject__c = 'Account';
+		oldRollupSummary.ChildObject__c = 'Contact';
+		oldRollupSummary.RelationShipField__c = 'AccountId';
+		oldRollupSummary.RelationShipCriteria__c = null;
+		oldRollupSummary.FieldToAggregate__c = 'LastCURequestDate';
+		oldRollupSummary.AggregateOperation__c = 'Count';
+		oldRollupSummary.AggregateResultField__c = 'AnnualRevenue';
+		oldRollupSummary.Active__c = false;
+		oldRollupSummary.CalculationMode__c = 'Realtime';
+
+		LookupRollupSummary__c newRollupSummary = oldRollupSummary.clone(true, true, true, true);
+		newRollupSummary.ChildObject__c = 'BadBadBadBadBadBadBadBadBadBad';
+		fflib_SObjectDomain.Test.Database.onUpdate(new LookupRollupSummary__c[] { newRollupSummary }, new Map<Id, SObject> { oldRollupSummary.Id => oldRollupSummary } );
+
+		fflib_SObjectDomain.triggerHandler(RollupSummaries.class);		
+		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());	
+		System.assertEquals('Object does not exist.', fflib_SObjectDomain.Errors.getAll()[0].message);
+		System.assertEquals(LookupRollupSummary__c.ChildObject__c, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field);		
+	}
 
 	/**
 	 * Issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/97


### PR DESCRIPTION
Had two options here - refactor to a common validation method that is called by both flavors of onValidate or enable Configuration.OldOnUpdateValidateBehaviour.  Decided to go with the former to avoid legacy based code.