### PR TITLE
Issue214 activation without trigger

### DIFF
--- a/rolluptool/src/classes/RollupSummaries.cls
+++ b/rolluptool/src/classes/RollupSummaries.cls
@@ -153,7 +153,9 @@ public class RollupSummaries extends fflib_SObjectDomain
 					lookupRollupSummary.AggregateResultField__c.addError(error('Field does not exist.', lookupRollupSummary, LookupRollupSummary__c.AggregateResultField__c));
 			}						
 			// Cannot activate Realtime or Scheduled rollup without the required trigger deployed
-			if(childObjectType!=null) 
+			// unless bypass is enabled
+			Boolean bypassTriggerCheck = (Boolean) DeclarativeLookupRollupSummaries__c.getInstance().BypassTriggerCheckDuringActivation__c;
+			if(childObjectType!=null && !bypassTriggerCheck) 
 			{
 				String triggerName = makeTriggerName(lookupRollupSummary); 
 				if(lookupRollupSummary.Active__c &&

--- a/rolluptool/src/classes/RollupSummaries.cls
+++ b/rolluptool/src/classes/RollupSummaries.cls
@@ -85,8 +85,8 @@ public class RollupSummaries extends fflib_SObjectDomain
 	
 	/**
 	 * Validations for inserts and updates of records
-	 **/ 
-	public override void onValidate()
+	 **/ 	
+	private void validateCommon()
 	{
 		// Cache Apex Describes and calculate child object tigger names
 		Set<String> rollupTriggerNames = new Set<String>();
@@ -217,6 +217,24 @@ public class RollupSummaries extends fflib_SObjectDomain
 				lookupRollupSummary.addError(error(e.getMessage(), lookupRollupSummary));	
 			} 											
 		}
+	}
+
+	/**
+	 * Validations for inserts of records
+	 **/ 
+	public override void onValidate()
+	{
+		// invoke validation that should occur for insert & update		
+		validateCommon();
+	}
+
+	/**
+	 * Validations for updates of records
+	 **/ 
+	public override void onValidate(Map<Id,SObject> existingRecords)
+	{
+		// invoke validation that should occur for insert & update
+		validateCommon();
 	}
 
 	private static final String MSG_INVALID_CRITERIA = 'Relationship Criteria \'\'{0}\'\' is not valid, see SOQL documentation http://www.salesforce.com/us/developer/docs/soql_sosl/Content/sforce_api_calls_soql_select_conditionexpression.htm, error is \'\'{1}\'\'';

--- a/rolluptool/src/classes/RollupSummariesTest.cls
+++ b/rolluptool/src/classes/RollupSummariesTest.cls
@@ -174,6 +174,33 @@ private class RollupSummariesTest
 		System.assertEquals('Apex Trigger ' + RollupSummaries.makeTriggerName(rollupSummary) + ' has not been deployed. Click Manage Child Trigger and try again.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(LookupRollupSummary__c.Active__c, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field);
 	}
+
+	private testmethod static void testInsertActiveBypassValidation()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+		
+		// enable bypass of trigger check for this test
+		DeclarativeLookupRollupSummaries__c setting = DeclarativeLookupRollupSummaries__c.getInstance();
+		setting.BypassTriggerCheckDuringActivation__c = true;
+		upsert setting;
+
+		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
+		rollupSummary.Name = 'Max Birthday for Contacts related to an Account';
+		rollupSummary.ParentObject__c = 'Account';
+		rollupSummary.ChildObject__c = 'Contact';
+		rollupSummary.RelationShipField__c = 'AccountId';
+		rollupSummary.RelationShipCriteria__c = null;
+		rollupSummary.FieldToAggregate__c = 'LastCURequestDate';
+		rollupSummary.AggregateOperation__c = 'Count';
+		rollupSummary.AggregateResultField__c = 'AnnualRevenue';
+		rollupSummary.Active__c = true;
+		rollupSummary.CalculationMode__c = 'Realtime';
+		fflib_SObjectDomain.Test.Database.onInsert(new LookupRollupSummary__c[] { rollupSummary } );		
+		fflib_SObjectDomain.triggerHandler(RollupSummaries.class);		
+		System.assertEquals(0, fflib_SObjectDomain.Errors.getAll().size());	
+	}	
 	
 	private testmethod static void testInsertParentObjectValidation()
 	{

--- a/rolluptool/src/classes/RollupSummariesTest.cls
+++ b/rolluptool/src/classes/RollupSummariesTest.cls
@@ -88,7 +88,40 @@ private class RollupSummariesTest
 		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());	
 		System.assertEquals('Object does not exist.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(LookupRollupSummary__c.ChildObject__c, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field);		
-	}	
+	}
+
+	/**
+	 * Issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/212
+	 **/
+	private testmethod static void testUpdateBadChildBigName()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+		
+		String rsId = fflib_IDGenerator.generate(LookupRollupSummary__c.SObjectType);
+
+		LookupRollupSummary__c oldRollupSummary = new LookupRollupSummary__c(Id=rsId);
+		oldRollupSummary.Name = 'Max Birthday for Contacts related to an Account';
+		oldRollupSummary.ParentObject__c = 'Account';
+		oldRollupSummary.ChildObject__c = 'Contact';
+		oldRollupSummary.RelationShipField__c = 'AccountId';
+		oldRollupSummary.RelationShipCriteria__c = null;
+		oldRollupSummary.FieldToAggregate__c = 'LastCURequestDate';
+		oldRollupSummary.AggregateOperation__c = 'Count';
+		oldRollupSummary.AggregateResultField__c = 'AnnualRevenue';
+		oldRollupSummary.Active__c = false;
+		oldRollupSummary.CalculationMode__c = 'Realtime';
+
+		LookupRollupSummary__c newRollupSummary = oldRollupSummary.clone(true, true, true, true);
+		newRollupSummary.ChildObject__c = 'BadBadBadBadBadBadBadBadBadBad';
+		fflib_SObjectDomain.Test.Database.onUpdate(new LookupRollupSummary__c[] { newRollupSummary }, new Map<Id, SObject> { oldRollupSummary.Id => oldRollupSummary } );
+
+		fflib_SObjectDomain.triggerHandler(RollupSummaries.class);		
+		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());	
+		System.assertEquals('Object does not exist.', fflib_SObjectDomain.Errors.getAll()[0].message);
+		System.assertEquals(LookupRollupSummary__c.ChildObject__c, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field);		
+	}
 
 	/**
 	 * Issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/97

--- a/rolluptool/src/objects/DeclarativeLookupRollupSummaries__c.object
+++ b/rolluptool/src/objects/DeclarativeLookupRollupSummaries__c.object
@@ -4,6 +4,16 @@
     <customSettingsVisibility>Public</customSettingsVisibility>
     <enableFeeds>false</enableFeeds>
     <fields>
+        <fullName>BypassTriggerCheckDuringActivation__c</fullName>
+        <defaultValue>false</defaultValue>
+        <deprecated>false</deprecated>        
+        <description>By default (false), Trigger must exist in order to activate rollup.  Setting to true will allow rollup to be activate without requiring trigger exist.  This supports scenarios were rollups are invoked in separate trigger</description>
+        <externalId>false</externalId>
+        <inlineHelpText>Set to true to allow rollups to be activated without requiring a specifically named trigger</inlineHelpText>
+        <label>Bypass Trigger Check During Activation</label>
+        <type>Checkbox</type>
+    </fields>
+    <fields>
         <fullName>CalculateJobScopeSize__c</fullName>
         <defaultValue>100</defaultValue>
         <deprecated>false</deprecated>


### PR DESCRIPTION
Add global setting to support bypassing of trigger exists check during rollup summary activation.

Additional capabilities could be added to specify regex or "pattern" to enforce in addition to or instead of the bypass.  Given the possible combinations of naming conventions individual use, a simple bypass flag was added.  By default, triggers are still required to support activation.