### PR TITLE
Issue #226 - Master records with no changes are updated

### DIFF
--- a/rolluptool/src/classes/RollupService.cls
+++ b/rolluptool/src/classes/RollupService.cls
@@ -272,7 +272,6 @@ global with sharing class RollupService
 			for(LookupRollupSummary__c lookup : lookups)
 			{
 				fieldsToSearchForChanges.add(lookup.FieldToAggregate__c);
-				fieldsToSearchForChanges.add(lookup.RelationShipField__c);
 				if(lookup.RelationshipCriteriaFields__c!=null)
 					for(String criteriaField : lookup.RelationshipCriteriaFields__c.split('\r\n'))
 						fieldsToSearchForChanges.add(criteriaField);
@@ -283,6 +282,11 @@ global with sharing class RollupService
 			Set<String> fieldsChanged = new Set<String>();  
 			for(SObject childRecord : childRecords)
 			{
+				// keep track of whether or not this child has changed in any of the fields involved in
+				// lookups that are NOT relationship fields themselves.  We'll check relationship fields
+				// separately to avoid unnecessary rollups firing on master records that don't require updating				
+				Boolean nonRelationshipFieldsChanged = false;
+
 				// Determine if any of the fields referenced on our selected rollups have changed on this record
 				for(String fieldToSearch : fieldsToSearchForChanges)
 				{
@@ -291,14 +295,43 @@ global with sharing class RollupService
 					Object oldValue = oldChildRecord.get(fieldToSearch);
 					// Register this field as having changed?
 					if(newValue != oldValue)
+					{
 						fieldsChanged.add(fieldToSearch);
-					// Add both old and new value to master record Id list for relationship fields to ensure old and new parent master records are updated (re-parenting)
-					if(relationshipFields.contains(fieldToSearch))
+						nonRelationshipFieldsChanged = true;
+					}
+				}
+
+				// iterate relationship fields looking and track old/new master id
+				// if there were changes to the relationship field itself or any 
+				// other fields involved in a lookup
+				for(String relationshipField : relationshipFields)
+				{
+					// should we add associated master to list?
+					// default to whether or not a non-relationship field on record has changed
+					Boolean addMasterIds = nonRelationshipFieldsChanged;
+
+					// capture old/new values
+					SObject oldChildRecord = Trigger.oldMap.get(childRecord.Id);
+					Object newValue = childRecord.get(relationshipField);
+					Object oldValue = oldChildRecord.get(relationshipField);
+
+					// Register this field as having changed?
+					if(newValue != oldValue)
+					{
+						fieldsChanged.add(relationshipField);
+						// master field itself changed so we force old/new master ids to be added for processing
+						addMasterIds = true;
+					}
+
+					// if relationship field itself changed or if change in another non-relationship field
+					// Add both old and new value to master record Id list for relationship fields 
+					// to ensure old and new parent master records are updated (re-parenting)
+					if (addMasterIds)
 					{
 						if(newValue!=null)
 							masterRecordIds.add((Id) newValue);
 						if(oldValue!=null)
-							masterRecordIds.add((Id) oldValue);		
+							masterRecordIds.add((Id) oldValue);
 					}
 				}
 			}

--- a/rolluptool/src/classes/RollupServiceTest.cls
+++ b/rolluptool/src/classes/RollupServiceTest.cls
@@ -1362,11 +1362,6 @@ private with sharing class RollupServiceTest
 		update oppsToModify;
 
 		// Assert limits
-		// TODO: Remove debug statements - in-place to get full picture when test fails
-		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% Queries - before:{0} after:{1}', new List<String> { String.valueOf(beforeQueries), String.valueOf(Limits.getQueries()) }));
-		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% QueryRows - before:{0} after:{1}', new List<String> { String.valueOf(beforeRows), String.valueOf(Limits.getQueryRows()) }));
-		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% DMLRows - before:{0} after:{1}', new List<String> { String.valueOf(beforeDMLRows), String.valueOf(Limits.getDMLRows()) }));
-
 		// + One query on Rollup object
 		// + One query on Opportunity for rollup	
 		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
@@ -1477,11 +1472,6 @@ private with sharing class RollupServiceTest
 		update children;
 
 		// Assert limits
-		// TODO: Remove debug statements - in-place to get full picture when test fails
-		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% Queries - before:{0} after:{1}', new List<String> { String.valueOf(beforeQueries), String.valueOf(Limits.getQueries()) }));
-		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% QueryRows - before:{0} after:{1}', new List<String> { String.valueOf(beforeRows), String.valueOf(Limits.getQueryRows()) }));
-		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% DMLRows - before:{0} after:{1}', new List<String> { String.valueOf(beforeDMLRows), String.valueOf(Limits.getDMLRows()) }));
-
 		// + One query on Rollup object
 		// + One query on LookupChild__c for rollup	
 		System.assertEquals(beforeQueries + 2, Limits.getQueries());	

--- a/rolluptool/src/classes/RollupServiceTest.cls
+++ b/rolluptool/src/classes/RollupServiceTest.cls
@@ -1275,4 +1275,234 @@ private with sharing class RollupServiceTest
 		System.assertEquals('Red;Yellow;Blue', (String) assertParents.get(parentB.id).get(aggregateResultField));
 		System.assertEquals('Red;Yellow', (String) assertParents.get(parentC.id).get(aggregateResultField));
 	}
+
+	private testmethod static void testLimitsConsumedWithSingleChildChanged()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		// Disable the Account trigger for this test, its carefully caluculated test actuals are thrown when this is enabled as well
+		TestContext.AccountTestTriggerEnabled = false;			
+
+		// Configure rollup
+		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
+		rollupSummary.Name = 'Total Opportunities into Annual Revenue on Account';
+		rollupSummary.ParentObject__c = 'Account';
+		rollupSummary.ChildObject__c = 'Opportunity';
+		rollupSummary.RelationShipField__c = 'AccountId';
+		rollupSummary.RelationShipCriteria__c = null;
+		rollupSummary.FieldToAggregate__c = 'Amount';
+		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
+		rollupSummary.AggregateResultField__c = 'AnnualRevenue';
+		rollupSummary.Active__c = true;
+		rollupSummary.CalculationMode__c = 'Realtime';
+		insert rollupSummary;
+		
+		// Test data
+		Integer numAccounts = 3;
+		Account parentAccount1 = new Account();
+		parentAccount1.Name = 'Parent Account 1';
+		parentAccount1.AnnualRevenue = 0;
+		Account parentAccount2 = new Account();
+		parentAccount2.Name = 'Parent Account 2';
+		parentAccount2.AnnualRevenue = 0;
+		Account parentAccount3 = new Account();
+		parentAccount3.Name = 'Parent Account 3';
+		parentAccount3.AnnualRevenue = 0;		
+		List<Account> parentAccounts = new List<Account> { parentAccount1, parentAccount2, parentAccount3 };
+		insert parentAccounts;
+
+		List<Decimal> oppAmounts = new List<Decimal> { 100, 200, 300, 400 };
+		Decimal expectedAnnualRevenue = 1000;
+		List<Opportunity> childOpportunities = new List<Opportunity>(); 		
+		for (Account acct :parentAccounts)
+		{
+			for(Decimal oppAmount :oppAmounts)
+			{
+				Opportunity opp = new Opportunity();
+				opp.Name = 'Test Opportunity for ' + acct.Name;
+				opp.StageName = 'Open';
+				opp.CloseDate = System.today();
+				opp.AccountId = acct.Id;
+				opp.Amount = oppAmount;
+				childOpportunities.add(opp);			
+			}			
+		}
+		insert childOpportunities;
+
+		// assert rollup produced correct values
+		System.assertEquals(expectedAnnualRevenue, [select AnnualRevenue from Account where Id = :parentAccount1.Id].AnnualRevenue);
+		System.assertEquals(expectedAnnualRevenue, [select AnnualRevenue from Account where Id = :parentAccount2.Id].AnnualRevenue);
+		System.assertEquals(expectedAnnualRevenue, [select AnnualRevenue from Account where Id = :parentAccount3.Id].AnnualRevenue);
+
+		// change opportunities on 'Parent Account 1' leaving 'Parent Account 2' opportunities untouched
+		List<Opportunity> oppsToModify = [SELECT Id, Name, Amount FROM Opportunity];
+		System.assertEquals(oppAmounts.size() * parentAccounts.size(), oppsToModify.size());
+		for (Opportunity oppToModify :oppsToModify)
+		{
+			// modify the CloseDate for all opps
+			// this simulates a change to a record on a field that is not involved any rollup
+			oppToModify.CloseDate = System.today().addMonths(1);
+
+			// modify Amount on the Opportunity associated to Parent Account 1 and it's current amount is 100
+			// this simulates a change to a single record on a field that is involved in a rollup
+			if (oppToModify.Name.endsWith(parentAccount1.Name) && oppToModify.Amount == 100)
+			{
+				oppToModify.Amount++;
+			}
+		}
+
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		// Update opportunities (1 record has change to field being aggregated, all others do not have changes to that field)		
+		update oppsToModify;
+
+		// Assert limits
+		// TODO: Remove debug statements - in-place to get full picture when test fails
+		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% Queries - before:{0} after:{1}', new List<String> { String.valueOf(beforeQueries), String.valueOf(Limits.getQueries()) }));
+		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% QueryRows - before:{0} after:{1}', new List<String> { String.valueOf(beforeRows), String.valueOf(Limits.getQueryRows()) }));
+		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% DMLRows - before:{0} after:{1}', new List<String> { String.valueOf(beforeDMLRows), String.valueOf(Limits.getDMLRows()) }));
+
+		// + One query on Rollup object
+		// + One query on Opportunity for rollup	
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
+		
+		// + One row for Rollup object
+		// + Four rows for Opportunity on Parent 1
+		System.assertEquals(beforeRows + 5, Limits.getQueryRows());
+
+		// + Twelve rows for Oppportunities (from the update statement itself)
+		// + One row for Parent Account 1 (from lookup processing)
+		System.assertEquals(beforeDMLRows + 13, Limits.getDMLRows());
+
+		// assert rollups produced correct result
+		System.assertEquals(expectedAnnualRevenue + 1, [select AnnualRevenue from Account where Id = :parentAccount1.Id].AnnualRevenue);
+		System.assertEquals(expectedAnnualRevenue, [select AnnualRevenue from Account where Id = :parentAccount2.Id].AnnualRevenue);
+		System.assertEquals(expectedAnnualRevenue, [select AnnualRevenue from Account where Id = :parentAccount3.Id].AnnualRevenue);		
+	}
+
+	private testmethod static void testLimitsConsumedWithReparentOnly()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField1 = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String relationshipField2 = LookupChild__c.LookupParent2__c.getDescribe().getName();
+		String aggregateField1 = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateField2 = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField1 = LookupParent__c.Colours__c.getDescribe().getName();
+		String aggregateResultField2 = LookupParent__c.Total2__c.getDescribe().getName();
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup';
+		rollupSummaryA.ParentObject__c = parentObjectName;
+		rollupSummaryA.ChildObject__c = childObjectName;
+		rollupSummaryA.RelationShipField__c = relationshipField1;
+		rollupSummaryA.FieldToAggregate__c = aggregateField1;
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.Concatenate.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultField1;
+		rollupSummaryA.ConcatenateDelimiter__c = ';';
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField2;
+		rollupSummaryB.FieldToAggregate__c = aggregateField2;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();		
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		SObject child1 = childType.newSObject();
+		child1.put(relationshipField1, parentA.Id);
+		child1.put(relationshipField2, parentB.Id);
+		child1.put(aggregateField1, 'Red');
+		child1.put(aggregateField2, 20);
+		SObject child2 = childType.newSObject();
+		child2.put(relationshipField1, parentA.Id);
+		child2.put(relationshipField2, parentB.Id);
+		child2.put(aggregateField1, 'Yellow');
+		child2.put(aggregateField2, 22);		
+
+		List<SObject> children = new List<SObject> { child1, child2 };
+		insert children;
+
+		// Assert rollups
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultField1, aggregateResultField2, parentObjectName })));
+		System.assertEquals('Red;Yellow', (String) assertParents.get(parentA.id).get(aggregateResultField1));
+		System.assertEquals(0.0, (Decimal) assertParents.get(parentA.id).get(aggregateResultField2));
+
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultField1));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField2));
+
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultField1));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField2));
+
+		// change LookupParent2__c from Parent B to Parent C
+		child1.put(relationshipField2, parentC.Id);
+
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		// update including all children but only one child and only one field (LookupParent2__c) on that child has changed
+		update children;
+
+		// Assert limits
+		// TODO: Remove debug statements - in-place to get full picture when test fails
+		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% Queries - before:{0} after:{1}', new List<String> { String.valueOf(beforeQueries), String.valueOf(Limits.getQueries()) }));
+		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% QueryRows - before:{0} after:{1}', new List<String> { String.valueOf(beforeRows), String.valueOf(Limits.getQueryRows()) }));
+		System.debug(LoggingLevel.ERROR, String.format('%%LIMITS%% DMLRows - before:{0} after:{1}', new List<String> { String.valueOf(beforeDMLRows), String.valueOf(Limits.getDMLRows()) }));
+
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup	
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
+		
+		// + Two rows for Rollup object
+		// + Two rows for LookupChild__c for rollup B (One on Parent B and One on Parent C)
+		System.assertEquals(beforeRows + 4, Limits.getQueryRows());
+
+		// + Two rows for LookupChild__c (from the update statement itself)
+		// + Two rows for LookupParent__c (One for B and One for C)
+		System.assertEquals(beforeDMLRows + 4, Limits.getDMLRows());		
+
+		// Assert rollups
+		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultField1, aggregateResultField2, parentObjectName })));
+		System.assertEquals('Red;Yellow', (String) assertParents.get(parentA.id).get(aggregateResultField1));
+		System.assertEquals(0.0, (Decimal) assertParents.get(parentA.id).get(aggregateResultField2));
+
+		System.assertEquals(null, (String) assertParents.get(parentB.id).get(aggregateResultField1));
+		System.assertEquals(22, (Decimal) assertParents.get(parentB.id).get(aggregateResultField2));
+
+		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultField1));
+		System.assertEquals(20, (Decimal) assertParents.get(parentC.id).get(aggregateResultField2));
+	}	
 }

--- a/rolluptool/src/classes/RollupServiceTest3.cls
+++ b/rolluptool/src/classes/RollupServiceTest3.cls
@@ -571,7 +571,6 @@ private with sharing class RollupServiceTest3
 		List<SObject> children = new List<SObject>();
 		for(SObject parent : parents)
 		{
-			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
 			child1.put(relationshipField, parent.Id);
 			child1.put(aggregateField, 20);
@@ -593,8 +592,23 @@ private with sharing class RollupServiceTest3
 		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
 		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
 
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeQueryRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
 		// Call developer 'trigger like' API
 		RollupService.rollup(null, new Map<Id, SObject>(children), childType);
+
+		// Assert no further limits have been used since the field to aggregate on the detail has not changed
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());
+		// + One row for Rollup object
+		// + Nine rows for LookupChild__c for rollup
+		System.assertEquals(beforeQueryRows + 10, Limits.getQueryRows());
+		// + Three rows for LookupParent__c for rollup target
+		System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());
 
 		// Assert parents are updated
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
@@ -648,7 +662,6 @@ private with sharing class RollupServiceTest3
 		List<SObject> children = new List<SObject>();
 		for(SObject parent : parents)
 		{
-			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
 			child1.put(relationshipField, parent.Id);
 			child1.put(aggregateField, 20);
@@ -682,7 +695,7 @@ private with sharing class RollupServiceTest3
 		// Assert no further limits have been used since the field to aggregate on the detail has not changed
 		System.assertEquals(beforeQueries + 1, Limits.getQueries()); // Only tolerate a query for the Lookup definition
 		System.assertEquals(beforeQueryRows + 1, Limits.getQueryRows()); // Only tolerate a row for the Lookup definition
-		System.assertEquals(beforeDMLRows, Limits.getDMLRows()); // No changes so not record should be operated against
+		System.assertEquals(beforeDMLRows, Limits.getDMLRows()); // No changes so no record should be operated against
 
 		// Assert parents are updated
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
@@ -736,7 +749,6 @@ private with sharing class RollupServiceTest3
 		List<SObject> children = new List<SObject>();
 		for(SObject parent : parents)
 		{
-			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
 			child1.put(relationshipField, parent.Id);
 			child1.put(aggregateField, 0);
@@ -763,23 +775,44 @@ private with sharing class RollupServiceTest3
 		System.assertEquals(9, modifiedChildren.size());
 		for (SObject child :modifiedChildren)
 		{
-			child.put(aggregateField, 14);
+			// do not update ParentC children so we can simulate
+			// only updated records being processed, non-changed records being ignored
+			// and assert governor limits to confirm			
+			if (child.get(relationshipField) != parentC.Id)
+			{
+				child.put(aggregateField, 14);
+			}
 		}
 		update modifiedChildren;
 
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeQueryRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
 		// Call developer 'trigger like' API simulating an update
 		RollupService.rollup(new Map<Id, SObject>(children), new Map<Id, SObject>(modifiedChildren), childType);
+
+		// Assert no further limits have been used since the field to aggregate on the detail has not changed
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());
+		// + One row for Rollup object
+		// + Six rows for LookupChild__c for rollup for Parent A & Parent B
+		System.assertEquals(beforeQueryRows + 7, Limits.getQueryRows());
+		// + Two rows for LookupParent__c for rollup target for Parent A & Parent B
+		System.assertEquals(beforeDMLRows + 2, Limits.getDMLRows());
 
 		// Assert parents are updated
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
 		System.assertEquals(3, assertParents.size());
 		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
 		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
-		System.assertEquals(42, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
 	}
 
 	/**
-	 * Test simulation of combination of isInsert and isUpdate
+	 * Test simulation of combination of isInsert and isUpdate but updates do not effect rollups
 	 */
 	private testmethod static void testDeveloperTriggerLikeAPI_SingleSumInsertedWithExistingThatDoNotChange()
 	{	
@@ -822,7 +855,6 @@ private with sharing class RollupServiceTest3
 		List<SObject> children = new List<SObject>();
 		for(SObject parent : parents)
 		{
-			String name = (String) parent.get('Name');
 			SObject child1 = childType.newSObject();
 			child1.put(relationshipField, parent.Id);
 			child1.put(aggregateField, 20);
@@ -844,10 +876,17 @@ private with sharing class RollupServiceTest3
 		List<SObject> newChildren = new List<SObject>();
 		for(SObject parent : parents)
 		{
-			SObject child3 = childType.newSObject();
-			child3.put(relationshipField, parent.Id);
-			child3.put(aggregateField, 2);
-			newChildren.add(child3);
+			// do not create new child for ParentC so we can simulate
+			// only inserted records being processed, non-changed records being ignored
+			// and assert governor limits to confirm
+			String name = (String) parent.get('Name');			
+			if(!name.equals('ParentC'))
+			{			
+				SObject child3 = childType.newSObject();
+				child3.put(relationshipField, parent.Id);
+				child3.put(aggregateField, 2);
+				newChildren.add(child3);
+			}
 		}
 		insert newChildren;
 
@@ -861,15 +900,30 @@ private with sharing class RollupServiceTest3
 		List<SObject> newAndOldChildren = children.clone();
 		newAndOldChildren.addAll(newChildren);
 
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeQueryRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
 		// Call developer 'trigger like' API simulating an update
 		RollupService.rollup(new Map<Id, SObject>(children), new Map<Id, SObject>(newAndOldChildren), childType);
+
+		// Assert no further limits have been used since the field to aggregate on the detail has not changed
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());
+		// + One row for Rollup object
+		// + Six rows for LookupChild__c for rollup for Parent A & Parent B
+		System.assertEquals(beforeQueryRows + 7, Limits.getQueryRows());
+		// + Two rows for LookupParent__c for rollup target for Parent A & Parent B
+		System.assertEquals(beforeDMLRows + 2, Limits.getDMLRows());
 
 		// Assert parents are updated
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
 		System.assertEquals(3, assertParents.size());
 		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
 		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
-		System.assertEquals(42, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
 	}
 
 	/**
@@ -947,8 +1001,23 @@ private with sharing class RollupServiceTest3
 		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
 		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
 
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeQueryRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
 		// Call developer 'trigger like' API simulating a delete
 		RollupService.rollup(new Map<Id, SObject>(deletedChildren), null, childType);
+
+		// Assert no further limits have been used since the field to aggregate on the detail has not changed
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());
+		// + One row for Rollup object
+		// + Three rows for LookupChild__c
+		System.assertEquals(beforeQueryRows + 4, Limits.getQueryRows());
+		// + Three rows for LookupParent__c
+		System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());
 
 		// Assert parents are updated
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
@@ -1049,8 +1118,23 @@ private with sharing class RollupServiceTest3
 		System.assertEquals(null, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
 		System.assertEquals(null, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
 
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeQueryRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
 		// Call developer 'trigger like' API simulating a undelete
 		RollupService.rollup(null, new Map<Id, SObject>(childrenToUndelete), childType);
+
+		// Assert no further limits have been used since the field to aggregate on the detail has not changed
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());
+		// + One row for Rollup object
+		// + Six rows for LookupChild__c
+		System.assertEquals(beforeQueryRows + 7, Limits.getQueryRows());
+		// + Three rows for LookupParent__c
+		System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());
 
 		// Assert parents are updated
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));

--- a/rolluptool/src/layouts/LookupChild__c-Lookup Child Layout.layout
+++ b/rolluptool/src/layouts/LookupChild__c-Lookup Child Layout.layout
@@ -22,6 +22,10 @@
                 <behavior>Edit</behavior>
                 <field>Color__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>LookupParent2__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/rolluptool/src/layouts/LookupParent__c-Lookup Parent Layout.layout
+++ b/rolluptool/src/layouts/LookupParent__c-Lookup Parent Layout.layout
@@ -61,6 +61,10 @@
         <fields>NAME</fields>
         <relatedList>LookupChild__c.LookupParent__c</relatedList>
     </relatedLists>
+    <relatedLists>
+        <fields>NAME</fields>
+        <relatedList>LookupChild__c.LookupParent2__c</relatedList>
+    </relatedLists>
     <showEmailCheckbox>false</showEmailCheckbox>
     <showHighlightsPanel>false</showHighlightsPanel>
     <showInteractionLogPanel>false</showInteractionLogPanel>

--- a/rolluptool/src/objects/LookupChild__c.object
+++ b/rolluptool/src/objects/LookupChild__c.object
@@ -94,6 +94,19 @@
         <type>Picklist</type>
     </fields>
     <fields>
+        <fullName>LookupParent2__c</fullName>
+        <deleteConstraint>SetNull</deleteConstraint>
+        <deprecated>false</deprecated>        
+        <externalId>false</externalId>
+        <label>Lookup Parent 2</label>
+        <referenceTo>LookupParent__c</referenceTo>
+        <relationshipLabel>Lookup Children (Lookup Parent 2)</relationshipLabel>
+        <relationshipName>LookupChildren2</relationshipName>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Lookup</type>
+    </fields>
+    <fields>
         <fullName>LookupParent__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
         <deprecated>false</deprecated>


### PR DESCRIPTION
See commit https://github.com/jondavis9898/declarative-lookup-rollup-summaries/commit/66b8e64aadd40b69eafb0f1a11134eb87db1eafc for tests that demonstrate issue.  Merging this commit in to existing code base separately will demonstrate failure.  This commit contains extra debug statements to make seeing expected vs. actual easier since asserts fail (set logging level to ERROR and look for %%LIMITS%%).

See commit https://github.com/jondavis9898/declarative-lookup-rollup-summaries/commit/e855153e8cf477b7e4cc20f5fc0c8bc5c7ca54fb for proposed fix.  This commit removes extra debug statements.