### PR TITLE
Issue #216, #239 & #240 - add order by support of multiple fields, ASC/DESC and NULLS FIRST/LAST; move orderby to context; fix to ensure recalc when order by field changes

### DIFF
--- a/rolluptool/src/classes/LREngine.cls
+++ b/rolluptool/src/classes/LREngine.cls
@@ -459,25 +459,33 @@ public class LREngine {
         }
 
         public boolean isAggregateBasedRollup() {
-            return operation == RollupOperation.Sum ||
-                operation == RollupOperation.Min ||
-                operation == RollupOperation.Max ||
-                operation == RollupOperation.Avg ||
-                operation == RollupOperation.Count ||
-                operation == RollupOperation.Count_Distinct;
+            return isAggregateBasedRollup(operation);
         }
 
         public boolean isQueryBasedRollup() {
-            return operation == RollupOperation.Concatenate ||
-                operation == RollupOperation.Concatenate_Distinct ||
-                operation == RollupOperation.First ||
-                operation == RollupOperation.Last;
+            return isQueryBasedRollup(operation);
         }
     }
     
     public enum SharingMode {
         User,
         System_x
+    }
+
+    public static boolean isAggregateBasedRollup(RollupOperation operation) {
+        return operation == RollupOperation.Sum ||
+            operation == RollupOperation.Min ||
+            operation == RollupOperation.Max ||
+            operation == RollupOperation.Avg ||
+            operation == RollupOperation.Count ||
+            operation == RollupOperation.Count_Distinct;
+    }
+
+    public static boolean isQueryBasedRollup(RollupOperation operation) {
+        return operation == RollupOperation.Concatenate ||
+            operation == RollupOperation.Concatenate_Distinct ||
+            operation == RollupOperation.First ||
+            operation == RollupOperation.Last;        
     }
 
     /**

--- a/rolluptool/src/classes/LREngine.cls
+++ b/rolluptool/src/classes/LREngine.cls
@@ -127,15 +127,12 @@ public class LREngine {
         
         // #0 token : SOQL projection
         String soqlProjection = ctx.lookupField.getName();
-        List<String> orderByFields = new List<String>();
-        orderByFields.add(ctx.lookupField.getName()); // ensure details records are ordered by parent record
 
         // k: detail field name, v: master field name
         Integer exprIdx = 0;
         Boolean needsCurrency = false;
         Boolean builtAggregateQuery = false;
         Set<String> selectedFields = new Set<String>();
-        Set<String> orderByFieldsSet = new Set<String>();
         Map<String, RollupSummaryField> rsfByAlais = new Map<String, RollupSummaryField>();
         for (RollupSummaryField rsf : ctx.fieldsToRoll) {
             if(rsf.operation == RollupOperation.Sum ||
@@ -161,14 +158,6 @@ public class LREngine {
                     soqlProjection += ', ' + selectField;
                     selectedFields.add(selectField);                    
                 }
-                // create order by projections
-                // i.e. Amount ASC NULLS FIRST
-                String orderByField = 
-                    rsf.detailOrderBy!=null ? rsf.detailOrderBy.getName() : rsf.detail.getName();
-                if(!orderByFieldsSet.contains(orderByField)) {
-                    orderByFields.add(orderByField);
-                    orderByFieldsSet.add(orderByField);
-                }
             }
         }
         
@@ -191,6 +180,10 @@ public class LREngine {
         // #3 Group by field
         String grpByFld = ctx.lookupField.getName();
 
+        // #4 Order by clause fields
+        // i.e. Amount ASC NULLS FIRST, Name DESC NULL LAST
+        String orderByClause = ctx.lookupField.getName() + (String.isBlank(ctx.detailOrderByClause) ? '' : (',' + ctx.detailOrderByClause));
+
         // build approprite soql for this rollup context
         String soql =
             builtAggregateQuery ? 
@@ -206,7 +199,7 @@ public class LREngine {
                         detailTblName, 
                         ctx.lookupField.getName(), 
                         whereClause, 
-                        String.join(orderByFields, ',')});
+                        orderByClause});
         System.debug('SOQL is ' + soql);
 
         // validate only?
@@ -367,7 +360,6 @@ public class LREngine {
     public class RollupSummaryField {
         public Schema.Describefieldresult master;
         public Schema.Describefieldresult detail;
-        public Schema.Describefieldresult detailOrderBy;
         public RollupOperation operation;
         public String concatenateDelimiter;
         
@@ -383,17 +375,15 @@ public class LREngine {
 
         public RollupSummaryField(Schema.Describefieldresult m, 
                                          Schema.Describefieldresult d, RollupOperation op) {
-            this(m, d, null, op, null);
+            this(m, d, op, null);
         }
 
         public RollupSummaryField(Schema.Describefieldresult m, 
-                                         Schema.Describefieldresult d, 
-                                         Schema.Describefieldresult detailOrderBy,
+                                         Schema.Describefieldresult d,
                                          RollupOperation op,
                                          String concatenateDelimiter) {
             this.master = m;
             this.detail = d;
-            this.detailOrderBy = detailOrderBy;
             this.operation = op;
             this.concatenateDelimiter = concatenateDelimiter;
             // caching these derived attrbutes for once
@@ -511,7 +501,10 @@ public class LREngine {
         
         // Where clause or filters to apply while aggregating detail records
         public String detailWhereClause;            
-        
+
+        // Order By clause to apply while aggregating detail records
+        public String detailOrderByClause;
+
         public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
                            Schema.Describefieldresult lf) {
             this(m, d, lf, '');                             
@@ -519,15 +512,26 @@ public class LREngine {
         
         public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
                            Schema.Describefieldresult lf, String detailWhereClause) {
-            this(m, d, lf, detailWhereClause, null);                             
+            this(m, d, lf, detailWhereClause, (SharingMode)null);                             
         }
 
         public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
                            Schema.Describefieldresult lf, String detailWhereClause, SharingMode sharingMode) {
+            this(m, d, lf, detailWhereClause, sharingMode, null);
+        }
+
+        public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
+                           Schema.Describefieldresult lf, String detailWhereClause, String detailOrderByClause) {
+            this(m, d, lf, detailWhereClause, null, detailOrderByClause);
+        }
+
+        public Context(Schema.Sobjecttype m, Schema.Sobjecttype d, 
+                           Schema.Describefieldresult lf, String detailWhereClause, SharingMode sharingMode, String detailOrderByClause) {        
             this.master = m;
             this.detail = d;
             this.lookupField = lf;
             this.detailWhereClause = detailWhereClause;
+            this.detailOrderByClause = detailOrderByClause;
             this.fieldsToRoll = new List<RollupSummaryField>();
             this.sharingMode = sharingMode;
         }

--- a/rolluptool/src/classes/LREngine.cls
+++ b/rolluptool/src/classes/LREngine.cls
@@ -182,7 +182,9 @@ public class LREngine {
 
         // #4 Order by clause fields
         // i.e. Amount ASC NULLS FIRST, Name DESC NULL LAST
-        String orderByClause = ctx.lookupField.getName() + (String.isBlank(ctx.detailOrderByClause) ? '' : (',' + ctx.detailOrderByClause));
+        // in order to maintain backwards compat, if there is no orderby specified and if the context contains only one rollupsummaryfield
+        // add the detail field to the orderby.  See https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/239#issuecomment-136122959.
+        String orderByClause = ctx.lookupField.getName() + (String.isBlank(ctx.detailOrderByClause) ? (ctx.fieldsToRoll.size() == 1 ? (',' + ctx.fieldsToRoll[0].detail.getName()) : '') : (',' + ctx.detailOrderByClause));
 
         // build approprite soql for this rollup context
         String soql =

--- a/rolluptool/src/classes/RollupService.cls
+++ b/rolluptool/src/classes/RollupService.cls
@@ -776,7 +776,6 @@ global with sharing class RollupService
 			if(childFields==null)
 				gdFields.put(childObjectType, ((childFields = childObjectType.getDescribe().fields.getMap())));
 			SObjectField fieldToAggregate = childFields.get(lookup.FieldToAggregate__c);
-			SObjectField fieldToOrderBy = lookup.FieldToOrderBy__c!=null ? childFields.get(lookup.FieldToOrderBy__c) : null;
 			SObjectField relationshipField = childFields.get(lookup.RelationshipField__c);
 			SObjectField aggregateResultField = parentFields.get(lookup.AggregateResultField__c);
 			if(fieldToAggregate==null || relationshipField==null || aggregateResultField==null)
@@ -787,7 +786,6 @@ global with sharing class RollupService
 	            new LREngine.RollupSummaryField(
 					aggregateResultField.getDescribe(),
 					fieldToAggregate.getDescribe(),
-					fieldToOrderBy !=null ? fieldToOrderBy.getDescribe() : null, // field to order by on child
 					RollupSummaries.OPERATION_PICKLIST_TO_ENUMS.get(lookup.AggregateOperation__c),
 	            	lookup.ConcatenateDelimiter__c);
 
@@ -815,7 +813,8 @@ global with sharing class RollupService
                     childObjectType,  // child object                    
                     relationshipField.getDescribe(), // relationship field name
                     lookup.RelationShipCriteria__c,
-                    sharingMode); 
+                    sharingMode,
+                    lookup.FieldToOrderBy__c); 
 				engineCtxByParentRelationship.put(contextKey, lreContext);
 			}				
 			// Add the lookup

--- a/rolluptool/src/classes/RollupService.cls
+++ b/rolluptool/src/classes/RollupService.cls
@@ -539,12 +539,41 @@ global with sharing class RollupService
 			// Set of field names from the child used in the rollup to search for changes on
 			Set<String> fieldsToSearchForChanges = new Set<String>(); 
 			Set<String> relationshipFields = new Set<String>(); 
+			// keep track of fields that should trigger a rollup to be processed
+			// this avoids having to re-parse RelationshipCriteria & OrderBy fields during field change detection
+			Map<Id, Set<String>> fieldsInvolvedInLookup = new Map<Id, Set<String>>();
 			for(LookupRollupSummary__c lookup : lookups)
 			{
-				fieldsToSearchForChanges.add(lookup.FieldToAggregate__c);
-				if(lookup.RelationshipCriteriaFields__c!=null)
-					for(String criteriaField : lookup.RelationshipCriteriaFields__c.split('\r\n'))
-						fieldsToSearchForChanges.add(criteriaField);
+				Set<String> lookupFields = new Set<String>();				
+				lookupFields.add(lookup.FieldToAggregate__c);
+				if(!String.isBlank(lookup.RelationshipCriteriaFields__c)) {
+					for(String criteriaField : lookup.RelationshipCriteriaFields__c.split('\r\n')) {
+						lookupFields.add(criteriaField);
+					}
+				}
+				// only include order by fields when query based rollup (concat, first, last, etc.) since changes to them
+				// will not impact the outcome of an aggregate based rollup (sum, count, etc.)
+				if(LREngine.isQueryBasedRollup(RollupSummaries.OPERATION_PICKLIST_TO_ENUMS.get(lookup.AggregateOperation__c)) && !String.isBlank(lookup.FieldToOrderBy__c)) {
+					List<Utilities.Ordering> orderByFields = Utilities.parseOrderByClause(lookup.FieldToOrderBy__c);
+					if (orderByFields != null && !orderByFields.isEmpty()) {
+						for (Utilities.Ordering orderByField :orderByFields) {
+							lookupFields.add(orderByField.getField());
+						}
+					}
+				}
+
+				// add all lookup fields to our master list of fields to search for
+				fieldsToSearchForChanges.addAll(lookupFields);
+
+				// add relationshipfield to fields for this lookup
+				// this comes after adding to fieldsToSearchForChanges because we handle
+				// change detection separately for non-relationship fields and relationship fields
+				lookupFields.add(lookup.RelationShipField__c);
+
+				// add to map for later use
+				fieldsInvolvedInLookup.put(lookup.Id, lookupFields);
+
+				// add relationship field to master list of relationship fields
 				relationshipFields.add(lookup.RelationShipField__c);
 			}
 			
@@ -624,16 +653,14 @@ global with sharing class RollupService
 			for(LookupRollupSummary__c lookup : lookups)
 			{
 				// Are any of the changed fields used by this lookup?
-				Boolean processLookup = false; 
-				if(fieldsChanged.contains(lookup.FieldToAggregate__c) ||
-				   fieldsChanged.contains(lookup.RelationShipField__c))
-				   	processLookup = true;
-				if(lookup.RelationshipCriteriaFields__c!=null)
-					for(String criteriaField : lookup.RelationshipCriteriaFields__c.split('\r\n'))
-						if(fieldsChanged.contains(criteriaField))
-							processLookup = true;
-				if(processLookup)
-					lookupsToProcess.add(lookup);
+				Set<String> lookupFields = fieldsInvolvedInLookup.get(lookup.Id);
+				for (String lookupField :lookupFields) {
+					if (fieldsChanged.contains(lookupField)) {
+						// add lookup to be processed and exit for loop since we have our answer
+						lookupsToProcess.add(lookup);
+						break;
+					}
+				}
 			}
 			lookups = lookupsToProcess;
 			

--- a/rolluptool/src/classes/RollupServiceTest.cls
+++ b/rolluptool/src/classes/RollupServiceTest.cls
@@ -1103,9 +1103,15 @@ private with sharing class RollupServiceTest
 	}
 
 	/**
-	 * Current default behavior of LREngine is to order by relationship field then by the orderby
-	 * clause specified in the Context.  If no order by is specified in the context, the only field
-	 * that will be specified in the order by projection is the RelationshipField__c field.
+     * Current default behavior of LREngine is to build the order by clause based on the following
+     *    1) RelationshipField__c (context.lookupfield in LRE) then by
+     *    2) If FieldToOrderBy__c (context.detailOrderByClause in LRE) is blank:
+     *           If Context RollupSummaryFields.size() == 1 (context.fieldsToRoll) add FieldToAggregate__c (context.fieldsToRoll[0].detail in LRE)
+     *           If Context RollupSummaryFields.size() > 1 (context.fieldsToRoll) then do not add any additional fields to orderby
+     *    3) If FieldToOrderBy__c (context.detailOrderByClause in LRE) is not blank, add FieldToOrderBy__c to orderby
+     *
+     * This results in all queries having an order by of at least RelationshipField__c even if no orderby
+     * is specified in FieldToOrderBy__c.  
 	 *
 	 * Current default behavior of DLRS is to build the context with all rollupsummaries
 	 * retrieving them ordered by ParentObject__c (Account) and then by RelationshipField__c (e.g. AccountId)
@@ -1242,6 +1248,82 @@ private with sharing class RollupServiceTest
 		System.assertEquals(expectedResultA, accountResult.Sic);			
 		System.assertEquals(expectedResultB, accountResult.Description);			
 	}	
+
+	/**
+	 * Test default behavior with no order by making sure order is based on fieldtoaggregate
+	 *
+	 * See comment above setupMultiRollupDifferentTypes for information on how orderby is established
+	 *
+     * Note that there is no reliable method for testing the situation where multiple fields that do not have
+     * orderby specified and would share a context.  The reason for this is that the order is 
+     * non-deterministic and there is no way currently (without adding one) to evaluate the SOQL generated.
+     * Using debug statements, it's been verified that only RelationshipField__c is included in
+     * order by in this scenario.
+	 */	 
+	private testmethod static void testSingleQueryRollupNoOrderByVerifyDetailFieldIncludedInOrderBy()
+	{		
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Colours__c.getDescribe().getName();
+
+		// Create a picklist rollup
+		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
+		rollupSummary.Name = 'Test Rollup';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
+		rollupSummary.FieldToOrderBy__c = null;
+		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Concatenate.name();
+		rollupSummary.AggregateResultField__c = aggregateResultField;
+		rollupSummary.ConcatenateDelimiter__c = ';';
+		rollupSummary.Active__c = true;
+		rollupSummary.CalculationMode__c = 'Realtime';
+		insert rollupSummary;
+
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 'silver');
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 'orange');
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField, 'purple');
+			children.add(child3);
+		}
+		insert children;
+
+		// Assert rollups
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals('orange;purple;silver', (String) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals('orange;purple;silver', (String) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals('orange;purple;silver', (String) assertParents.get(parentC.id).get(aggregateResultField));			
+	}
 
 	private testmethod static void testPicklistRollup()
 	{		

--- a/rolluptool/src/classes/RollupServiceTest.cls
+++ b/rolluptool/src/classes/RollupServiceTest.cls
@@ -1103,27 +1103,17 @@ private with sharing class RollupServiceTest
 	}
 
 	/**
-	 * Current default behavior of LREngine  is to order by relationship field, then by each 
-	 * rollup summary detail field (FieldToAggregate__c) in the order specified (e.g. AccountId, StageName, Name)
-	 * within the context (RollupSummaryField order).  If no order by is specified on a rollupsummaryfield
-	 * the detail field is used for the order by following the Then By approach based on order
-	 * in the context.
+	 * Current default behavior of LREngine is to order by relationship field then by the orderby
+	 * clause specified in the Context.  If no order by is specified in the context, the only field
+	 * that will be specified in the order by projection is the RelationshipField__c field.
 	 *
 	 * Current default behavior of DLRS is to build the context with all rollupsummaries
 	 * retrieving them ordered by ParentObject__c (Account) and then by RelationshipField__c (e.g. AccountId)
-	 * which results in non-deterministic result so a test cannot reliabily be written against
-	 * multiple rollups on same parent/child relationship when no order by is specified.
+	 * which results in non-deterministic result when no orderby is specified so a test cannot reliabily be written against
+	 * multiple rollups on same parent/child relationship when no orderby is specified.
 	 */
-	private static Id setupMultiRollupDifferentTypes(RollupSummaries.AggregateOperation operationA, Schema.DescribeFieldResult orderByFieldA, RollupSummaries.AggregateOperation operationB, Schema.DescribeFieldResult orderByFieldB)
+	private static Id setupMultiRollupDifferentTypes(Map<String, String> opportunityData, RollupSummaries.AggregateOperation operationA, String orderByFieldA, RollupSummaries.AggregateOperation operationB, String orderByFieldB)
 	{
-		// Test data
-		// OpportunityName => Amount;CloseDateAddMonthsToToday;StageName
-		Map<String, String> opportunityData = new Map<String, String> {
-			'Joe' => '250;0;Open',
-			'Steve' => '50;1;Prospecting',
-			'Kim' => '100;-2;Closed Won',
-			'Charlie' => '225;-1;Needs Analysis'};
-
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'First Opportunity Name into Sic on Account';
@@ -1132,7 +1122,7 @@ private with sharing class RollupServiceTest
 		rollupSummaryA.RelationShipField__c = 'AccountId';
 		rollupSummaryA.RelationShipCriteria__c = null;
 		rollupSummaryA.FieldToAggregate__c = 'StageName';
-		rollupSummaryA.FieldToOrderBy__c = orderByFieldA != null ? orderByFieldA.getName() : null;
+		rollupSummaryA.FieldToOrderBy__c = orderByFieldA;
 		rollupSummaryA.AggregateOperation__c = operationA.name();
 		rollupSummaryA.AggregateResultField__c = 'Sic';
 		rollupSummaryA.Active__c = true;
@@ -1146,7 +1136,7 @@ private with sharing class RollupServiceTest
 		rollupSummaryB.RelationShipField__c = 'AccountId';
 		rollupSummaryB.RelationShipCriteria__c = null;
 		rollupSummaryB.FieldToAggregate__c = 'Name';
-		rollupSummaryB.FieldToOrderBy__c = orderByFieldB != null ? orderByFieldB.getName() : null;
+		rollupSummaryB.FieldToOrderBy__c = orderByFieldB;
 		rollupSummaryB.AggregateOperation__c = operationB.name();
 		rollupSummaryB.AggregateResultField__c = 'Description';
 		rollupSummaryB.ConcatenateDelimiter__c = ',';
@@ -1189,24 +1179,69 @@ private with sharing class RollupServiceTest
 		if(!TestContext.isSupported())
 			return;
 
+		// Test data
+		// OpportunityName => Amount;CloseDateAddMonthsToToday;StageName
+		Map<String, String> opportunityData = new Map<String, String> {
+			'Joe' => '250;0;Open',
+			'Steve' => '50;1;Prospecting',
+			'Kim' => '100;-2;Closed Won',
+			'Charlie' => '225;-1;Needs Analysis'};
+
 		// Test data for rollup A
 		String expectedResultA = 'Closed Won';
 		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.First;
-		Schema.DescribeFieldResult orderByFieldA = Schema.SObjectType.Opportunity.fields.CloseDate;
+		String orderByClauseA = Schema.SObjectType.Opportunity.fields.CloseDate.getName();
 
 		// Test data for rollup B
 		String expectedResultB = 'Steve,Kim,Charlie,Joe';
 		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate; 
-		Schema.DescribeFieldResult orderByFieldB = Schema.SObjectType.Opportunity.fields.Amount;
+		String orderByClauseB = Schema.SObjectType.Opportunity.fields.Amount.getName();
 
 		// generate rollups and data
-		Id accountId = setupMultiRollupDifferentTypes(operationA, orderByFieldA, operationB, orderByFieldB);
+		Id accountId = setupMultiRollupDifferentTypes(opportunityData, operationA, orderByClauseA, operationB, orderByClauseB);
 
 		// Assert rollup
 		Account accountResult = Database.query('select Sic, Description from Account where Id = :accountId');
 		System.assertEquals(expectedResultA, accountResult.Sic);			
 		System.assertEquals(expectedResultB, accountResult.Description);			
 	}
+
+	/**
+	 * Test default behavior with different order by containing multiple fields on each rollup
+	 * for Issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/216
+	 */	 
+	private testmethod static void testMultiRollupOfDifferentTypesDifferentMultipleFieldsOrderBy()
+	{		
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		// Test data
+		// OpportunityName => Amount;CloseDateAddMonthsToToday;StageName
+		Map<String, String> opportunityData = new Map<String, String> {
+			'Joe' => '100;0;Open',
+			'Steve' => '100;-2;Prospecting',
+			'Kim' => '100;1;Closed Won',
+			'Charlie' => '100;-1;Needs Analysis'};
+
+		// Test data for rollup A
+		String expectedResultA = 'Prospecting';
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.First;
+		String orderByClauseA = 'Amount ASC NULLS FIRST, CloseDate ASC NULLS FIRST, Name';
+
+		// Test data for rollup B
+		String expectedResultB = 'Kim,Joe,Charlie,Steve';
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate; 
+		String orderByClauseB = 'Amount ASC NULLS FIRST, CloseDate DESC NULLS FIRST, Name';
+
+		// generate rollups and data
+		Id accountId = setupMultiRollupDifferentTypes(opportunityData, operationA, orderByClauseA, operationB, orderByClauseB);
+
+		// Assert rollup
+		Account accountResult = Database.query('select Sic, Description from Account where Id = :accountId');
+		System.assertEquals(expectedResultA, accountResult.Sic);			
+		System.assertEquals(expectedResultB, accountResult.Description);			
+	}	
 
 	private testmethod static void testPicklistRollup()
 	{		
@@ -1495,4 +1530,92 @@ private with sharing class RollupServiceTest
 		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultField1));
 		System.assertEquals(20, (Decimal) assertParents.get(parentC.id).get(aggregateResultField2));
 	}	
+
+    private static void assertOrdering(Utilities.Ordering o, String orderBy, Boolean useAsSpecifiedString, String field, Utilities.SortOrder direction, Boolean nullsLast)
+    {
+        System.assertEquals(orderBy, useAsSpecifiedString ? o.toAsSpecifiedString() : o.toString());
+        System.assertEquals(field, o.getField());
+        System.assertEquals(direction, o.getDirection());
+        System.assertEquals(nullsLast, o.getNullsLast());
+    }
+
+    static testMethod void testOrderingStringification()
+    {
+        Utilities.Ordering o = new Utilities.Ordering('CloseDate');
+        assertOrdering(o, 'CloseDate ASC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
+
+        o = new Utilities.Ordering('closedate');
+        assertOrdering(o, 'closedate ASC NULLS FIRST', false, 'closedate', Utilities.SortOrder.ASCENDING, false);
+
+		o = new Utilities.Ordering('cLoSeDaTe');
+        assertOrdering(o, 'cLoSeDaTe ASC NULLS FIRST', false, 'cLoSeDaTe', Utilities.SortOrder.ASCENDING, false);
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING);
+        assertOrdering(o, 'CloseDate ASC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING);
+        assertOrdering(o, 'CloseDate DESC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.DESCENDING, false);
+
+        o = new Utilities.Ordering('CloseDate', null, false);
+        assertOrdering(o, 'CloseDate ASC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
+
+        o = new Utilities.Ordering('CloseDate', null, true);
+        assertOrdering(o, 'CloseDate ASC NULLS LAST', false,'CloseDate', Utilities.SortOrder.ASCENDING, true);
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING, false);
+        assertOrdering(o, 'CloseDate ASC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, false);        
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING, true);
+        assertOrdering(o, 'CloseDate ASC NULLS LAST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, true);        
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, false);
+        assertOrdering(o, 'CloseDate DESC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.DESCENDING, false);        
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, true);
+        assertOrdering(o, 'CloseDate DESC NULLS LAST', false, 'CloseDate', Utilities.SortOrder.DESCENDING, true);        
+
+         try {
+            o = new Utilities.Ordering(null);
+            System.assert(false, 'Expecting an exception');
+         }
+         catch (Utilities.BadOrderingStateException e) {
+            System.assertEquals('field cannot be blank.', e.getMessage());
+         }        
+    }
+
+    static testMethod void testOrderingAsSpecifiedStringification()
+    {
+        Utilities.Ordering o = new Utilities.Ordering('CloseDate');
+        assertOrdering(o, 'CloseDate', true, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
+
+        o = new Utilities.Ordering('closedate');
+        assertOrdering(o, 'closedate', true, 'closedate', Utilities.SortOrder.ASCENDING, false);
+
+		o = new Utilities.Ordering('cLoSeDaTe');
+        assertOrdering(o, 'cLoSeDaTe', true, 'cLoSeDaTe', Utilities.SortOrder.ASCENDING, false);
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING);
+        assertOrdering(o, 'CloseDate ASC', true, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING);
+        assertOrdering(o, 'CloseDate DESC', true, 'CloseDate', Utilities.SortOrder.DESCENDING, false);
+
+        o = new Utilities.Ordering('CloseDate', null, false);
+        assertOrdering(o, 'CloseDate NULLS FIRST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
+
+        o = new Utilities.Ordering('CloseDate', null, true);
+        assertOrdering(o, 'CloseDate NULLS LAST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, true);
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING, false);
+        assertOrdering(o, 'CloseDate ASC NULLS FIRST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, false);        
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING, true);
+        assertOrdering(o, 'CloseDate ASC NULLS LAST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, true);        
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, false);
+        assertOrdering(o, 'CloseDate DESC NULLS FIRST', true, 'CloseDate', Utilities.SortOrder.DESCENDING, false);        
+
+        o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, true);
+        assertOrdering(o, 'CloseDate DESC NULLS LAST', true, 'CloseDate', Utilities.SortOrder.DESCENDING, true);      
+    }  	
 }

--- a/rolluptool/src/classes/RollupServiceTest.cls
+++ b/rolluptool/src/classes/RollupServiceTest.cls
@@ -1618,4 +1618,226 @@ private with sharing class RollupServiceTest
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, true);
         assertOrdering(o, 'CloseDate DESC NULLS LAST', true, 'CloseDate', Utilities.SortOrder.DESCENDING, true);      
     }  	
+
+	private testmethod static void testSingleQueryBasedRollupUpdateOrderByFieldChanged()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Colours__c.getDescribe().getName();
+		String orderByField = LookupChild__c.Amount__c.getDescribe().getName();
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
+		rollupSummary.Name = 'Test Rollup';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
+		rollupSummary.FieldToOrderBy__c = orderByField;
+		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummary.AggregateResultField__c = aggregateResultField;
+		rollupSummary.ConcatenateDelimiter__c = ';';
+		rollupSummary.Active__c = true;
+		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();	
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummary };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 'Red');
+			child1.put(orderByField, 10);
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 'Yellow');
+			child2.put(orderByField, 20);
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField, 'Blue');
+			child3.put(orderByField, 30);
+			children.add(child3);
+		}
+		insert children;		
+
+		// Assert rollups
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals('Red', (String) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals('Red', (String) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals('Red', (String) assertParents.get(parentC.id).get(aggregateResultField));
+
+		// change Amount__c to effect order by result of rollup
+		// this change will result in rollup being processed because it is a query based rollup
+		// and order by influences rolled up value	
+		List<SObject> childrenToUpdate = new List<SObject>();
+		for (SObject child :children)
+		{
+			Decimal orderByFieldValue = (Decimal)child.get(orderByField);
+			if (orderByFieldValue == 10) {
+				child.put(orderByField, 40);
+				childrenToUpdate.add(child);
+			}
+		}
+
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		// update children
+		update childrenToUpdate;
+
+		// Assert limits
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup	
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
+		
+		// + One row for Rollup object
+		// + Nine rows for LookupChild__c for rollup
+		System.assertEquals(beforeRows + 10, Limits.getQueryRows());
+
+		// + Three rows for LookupChild__c (from the update statement itself)
+		// + Three rows for LookupParent__c for the rollup
+		System.assertEquals(beforeDMLRows + 6, Limits.getDMLRows());		
+
+		// Assert rollups
+		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals('Yellow', (String) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals('Yellow', (String) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals('Yellow', (String) assertParents.get(parentC.id).get(aggregateResultField));
+	}
+
+	private testmethod static void testSingleAggregateBasedRollupUpdateOrderByFieldChanged()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField = LookupParent__c.Total__c.getDescribe().getName();
+		String orderByField = LookupChild__c.Color__c.getDescribe().getName();
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
+		rollupSummary.Name = 'Test Rollup';
+		rollupSummary.ParentObject__c = parentObjectName;
+		rollupSummary.ChildObject__c = childObjectName;
+		rollupSummary.RelationShipField__c = relationshipField;
+		rollupSummary.FieldToAggregate__c = aggregateField;
+		rollupSummary.FieldToOrderBy__c = orderByField;
+		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
+		rollupSummary.AggregateResultField__c = aggregateResultField;
+		rollupSummary.ConcatenateDelimiter__c = ';';
+		rollupSummary.Active__c = true;
+		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();	
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummary };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField, 10);
+			child1.put(orderByField, 'Red');
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField, 20);
+			child2.put(orderByField, 'Yellow');
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField, 12);
+			child3.put(orderByField, 'Blue');
+			children.add(child3);
+		}
+		insert children;		
+
+		// Assert rollups
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals(42, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+
+		// change Color__c to effect order by result of rollup
+		// this change will NOT result in rollup being processed because it is a aggregate based rollup
+		// and order by does NOT influence rolled up result
+		List<SObject> childrenToUpdate = new List<SObject>();
+		for (SObject child :children)
+		{
+			String orderByFieldValue = (String)child.get(orderByField);
+			if (orderByFieldValue == 'Red') {
+				child.put(orderByField, 'Green');
+				childrenToUpdate.add(child);
+			}
+		}
+
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		// update children
+		update childrenToUpdate;
+
+		// Assert limits
+		// + One query on Rollup object
+		// No query on LookupChild__c because the changed Color__c should not be considered a change that would trigger the rollup to be processed
+		System.assertEquals(beforeQueries + 1, Limits.getQueries());	
+		
+		// + One row for Rollup object
+		// No rows on LookupChild__c because the changed Color__c should not be considered a change that would trigger the rollup to be processed		
+		System.assertEquals(beforeRows + 1, Limits.getQueryRows());
+
+		// + Three rows for LookupChild__c (from the update statement itself)
+		// No query on LookupParent__c because the changed Color__c should not be considered a change that would trigger the rollup to be processed		
+		System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());		
+
+		// Assert rollups
+		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
+		System.assertEquals(42, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
+	}
 }

--- a/rolluptool/src/classes/RollupServiceTest4.cls
+++ b/rolluptool/src/classes/RollupServiceTest4.cls
@@ -1461,8 +1461,7 @@ private class RollupServiceTest4 {
 	 *		- Different AggregateResultField__c
 	 *		- Different Order By two that have no order by specified
 	 *		- Effective values for all other fields same differing only by case used
-	 *	Should result in Two (2) contexts used, two SOQL for the rollup itself and 3 DML rows (1 for each 
-	 *		parent - DLRS combines updates to identical master record ids)
+	 *	Should result in a single context used, a single SOQL for all rollups and 3 DML rows (1 for each parent)	 
 	 **/	 
 	private testmethod static void testLimitsAndContextsUsedMultipleQueryRollupsNoOrderByShareSingleContext()
 	{

--- a/rolluptool/src/classes/RollupServiceTest4.cls
+++ b/rolluptool/src/classes/RollupServiceTest4.cls
@@ -1021,6 +1021,624 @@ private class RollupServiceTest4 {
 	}
 
 	/**
+	 *	Test for issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/239
+	 *	Two similar rollups differing by:
+	 *		- Different AggregateOperation__c (both use Query rollup - First/Last)
+	 *		- Different AggregateResultField__c
+	 *		- Different FieldToAggregate__c
+	 *		- Different Order By one that has no order by specified
+	 *		- Effective values for all other fields same differing only by case used
+	 *	Should result in Two (2) contexts used, two SOQL for the rollup itself and 3 DML rows (1 for each 
+	 *		parent - DLRS combines updates to identical master record ids)
+	 **/	 
+	private testmethod static void testLimitsAndContextsUsedMultipleQueryRollupsDifferByOperationAggResultFieldAggFieldCaseOrderByOneOrderByIsNull()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField1 = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateField2 = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField1 = LookupParent__c.Colours__c.getDescribe().getName();
+		String aggregateResultField2 = LookupParent__c.Total2__c.getDescribe().getName();
+		String condition = 'Amount__c > 1';
+		String relationshipCriteriaFields = 'Amount__c';
+		String sharingMode = LREngine.SharingMode.User.name();
+		String fieldToOrderBy = LookupChild__c.Amount__c.getDescribe().getName();
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup A';
+		rollupSummaryA.ParentObject__c = parentObjectName.toLowerCase();
+		rollupSummaryA.ChildObject__c = childObjectName.toLowerCase();
+		rollupSummaryA.RelationShipField__c = relationshipField.toLowerCase();
+		rollupSummaryA.RelationShipCriteria__c = condition;
+		rollupSummaryA.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryA.FieldToAggregate__c = aggregateField1.toLowerCase();
+		rollupSummaryA.FieldToOrderBy__c = fieldToOrderBy.toLowerCase();
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultField1.toLowerCase();
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryA.CalculationSharingMode__c = sharingMode.toLowerCase();		
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup B';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.RelationShipCriteria__c = condition;
+		rollupSummaryB.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryB.FieldToAggregate__c = aggregateField2;
+		rollupSummaryB.FieldToOrderBy__c = null;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Last.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryB.CalculationSharingMode__c = sharingMode;
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField1, 'Red');			
+			child1.put(aggregateField2, 42);
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField1, 'Yellow');
+			child2.put(aggregateField2, 15);
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField1, 'Blue');			
+			child3.put(aggregateField2, 10);
+			children.add(child3);
+		}
+
+		// Sample various limits prior to an insert
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		// insert child records
+		insert children;
+
+		// Assert limits
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup A
+		// + One query on LookupChild__c for rollup B
+		System.assertEquals(beforeQueries + 3, Limits.getQueries());	
+		
+		// + Two rows for Rollup object
+		// + Nine rows for LookupChild__c for rollup A
+		// + Nine rows for LookupChild__c for rollup B
+		System.assertEquals(beforeRows + 20, Limits.getQueryRows());
+
+		// + Nine rows for LookupChild__c (from the insert statement itself)
+		// + Three rows for LookupParent__c for rollup A & B (DLRS combined updates to identical master ids)
+		System.assertEquals(beforeDMLRows + 12, Limits.getDMLRows());		
+
+		// Assert rollups
+		// Note that we are able to reliably assert rollup B because even though it does not
+		// have orderby specified because it will receive a default orderby of FieldToAggregate__c since it is the only
+		// rollup in the "no order by specified" context
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultField1, aggregateResultField2, parentObjectName })));
+		System.assertEquals('Blue', (String) assertParents.get(parentA.id).get(aggregateResultField1));
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField2));
+
+		System.assertEquals('Blue', (String) assertParents.get(parentB.id).get(aggregateResultField1));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField2));
+
+		System.assertEquals('Blue', (String) assertParents.get(parentC.id).get(aggregateResultField1));
+		System.assertEquals(42, (Decimal) assertParents.get(parentC.id).get(aggregateResultField2));
+	}
+
+	/**
+	 *	Test for issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/239
+	 *	Three similar rollups differing by:
+	 *		- Different AggregateOperation__c (both use Query rollup - First/Last)
+	 *		- Different AggregateResultField__c
+	 *		- Different FieldToAggregate__c	 
+	 *		- Different Order By two that have no order by specified
+	 *		- Effective values for all other fields same differing only by case used
+	 *	Should result in Two (2) contexts used, two SOQL for the rollup itself and 3 DML rows (1 for each 
+	 *		parent - DLRS combines updates to identical master record ids)
+	 **/	 
+	private testmethod static void testLimitsAndContextsUsedMultipleQueryRollupsDifferByOperationAggResultFieldAggFieldCaseOrderByTwoOrderByIsNullSameFieldToAggregate()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField1 = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateField2 = LookupChild__c.Description__c.getDescribe().getName();
+		String aggregateField3 = LookupChild__c.Description__c.getDescribe().getName();
+		String aggregateResultField1 = LookupParent__c.Colours__c.getDescribe().getName();
+		String aggregateResultField2 = LookupParent__c.Descriptions__c.getDescribe().getName();
+		String aggregateResultField3 = LookupParent__c.Descriptions2__c.getDescribe().getName();
+		String condition = 'Description__c != null';
+		String relationshipCriteriaFields = 'Description__c';
+		String sharingMode = LREngine.SharingMode.User.name();
+		String fieldToOrderBy = LookupChild__c.Name.getDescribe().getName();
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup A';
+		rollupSummaryA.ParentObject__c = parentObjectName.toLowerCase();
+		rollupSummaryA.ChildObject__c = childObjectName.toLowerCase();
+		rollupSummaryA.RelationShipField__c = relationshipField.toLowerCase();
+		rollupSummaryA.RelationShipCriteria__c = condition;
+		rollupSummaryA.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryA.FieldToAggregate__c = aggregateField1.toLowerCase();
+		rollupSummaryA.FieldToOrderBy__c = fieldToOrderBy.toLowerCase();
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultField1.toLowerCase();
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryA.CalculationSharingMode__c = sharingMode.toLowerCase();		
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup B';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.RelationShipCriteria__c = condition;
+		rollupSummaryB.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryB.FieldToAggregate__c = aggregateField2;
+		rollupSummaryB.FieldToOrderBy__c = null;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Last.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryB.CalculationSharingMode__c = sharingMode;
+
+		LookupRollupSummary__c rollupSummaryC = new LookupRollupSummary__c();
+		rollupSummaryC.Name = 'Test Rollup C';
+		rollupSummaryC.ParentObject__c = parentObjectName;
+		rollupSummaryC.ChildObject__c = childObjectName;
+		rollupSummaryC.RelationShipField__c = relationshipField;
+		rollupSummaryC.RelationShipCriteria__c = condition;
+		rollupSummaryC.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryC.FieldToAggregate__c = aggregateField3;
+		rollupSummaryC.FieldToOrderBy__c = null;
+		rollupSummaryC.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryC.AggregateResultField__c = aggregateResultField3;
+		rollupSummaryC.Active__c = true;
+		rollupSummaryC.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryC.CalculationSharingMode__c = sharingMode;		
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB, rollupSummaryC };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put('Name', 'tom');
+			child1.put(aggregateField1, 'Red');			
+			child1.put(aggregateField2, 'lemon');
+			// aggregateField3 is same SObjectField as aggregateField2
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put('Name', 'charlie');			
+			child2.put(aggregateField1, 'Yellow');
+			child2.put(aggregateField2, 'pear');
+			// aggregateField3 is same SObjectField as aggregateField2
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put('Name', 'samantha');			
+			child3.put(aggregateField1, 'Blue');
+			child3.put(aggregateField2, 'apple');
+			// aggregateField3 is same SObjectField as aggregateField2
+			children.add(child3);		
+		}
+
+		// Sample various limits prior to an insert
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		// insert child records
+		insert children;
+
+		// Assert limits
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup A
+		// + One query on LookupChild__c for rollup B and for rollup C
+		System.assertEquals(beforeQueries + 3, Limits.getQueries());	
+		
+		// + Three rows for Rollup object
+		// + Nine rows for LookupChild__c for rollup A
+		// + Nine rows for LookupChild__c for rollup B and for rollup C
+		System.assertEquals(beforeRows + 21, Limits.getQueryRows());
+
+		// + Nine rows for LookupChild__c (from the insert statement itself)
+		// + Three rows for LookupParent__c for rollup A & B & C (DLRS combined updates to identical master ids)
+		System.assertEquals(beforeDMLRows + 12, Limits.getDMLRows());		
+
+		// Assert rollups
+		// Note that we are not able to reliably assert rollups B & C because they do not have orderby specified
+		// and will share a context.  Since more than one field will be involved in context no orderby will be applied beyond
+		// the RelationshipField__c
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultField1, aggregateResultField2, parentObjectName })));
+		System.assertEquals('Yellow', (String) assertParents.get(parentA.id).get(aggregateResultField1));
+		System.assertEquals('Yellow', (String) assertParents.get(parentB.id).get(aggregateResultField1));
+		System.assertEquals('Yellow', (String) assertParents.get(parentC.id).get(aggregateResultField1));
+	}
+
+	/**
+	 *	Test for issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/239
+	 *	Three similar rollups differing by:
+	 *		- Different AggregateOperation__c (both use Query rollup - First/Last)
+	 *		- Different AggregateResultField__c
+	 *		- Different Order By two that have no order by specified
+	 *		- Effective values for all other fields same differing only by case used
+	 *	Should result in Two (2) contexts used, two SOQL for the rollup itself and 3 DML rows (1 for each 
+	 *		parent - DLRS combines updates to identical master record ids)
+	 **/	 
+	private testmethod static void testLimitsAndContextsUsedMultipleQueryRollupsDifferByOperationFieldCaseOrderByTwoOrderByIsNullDifferentFieldToAggregate()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField1 = LookupChild__c.Description__c.getDescribe().getName();
+		String aggregateField2 = LookupChild__c.Description__c.getDescribe().getName();
+		String aggregateField3 = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateResultField1 = LookupParent__c.Descriptions__c.getDescribe().getName();
+		String aggregateResultField2 = LookupParent__c.Descriptions2__c.getDescribe().getName();
+		String aggregateResultField3 = LookupParent__c.Colours__c.getDescribe().getName();
+		String condition = 'Description__c != null';
+		String relationshipCriteriaFields = 'Description__c';
+		String sharingMode = LREngine.SharingMode.User.name();
+		String fieldToOrderBy = LookupChild__c.Description__c.getDescribe().getName();
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup A';
+		rollupSummaryA.ParentObject__c = parentObjectName.toLowerCase();
+		rollupSummaryA.ChildObject__c = childObjectName.toLowerCase();
+		rollupSummaryA.RelationShipField__c = relationshipField.toLowerCase();
+		rollupSummaryA.RelationShipCriteria__c = condition;
+		rollupSummaryA.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryA.FieldToAggregate__c = aggregateField1.toLowerCase();
+		rollupSummaryA.FieldToOrderBy__c = fieldToOrderBy.toLowerCase();
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultField1.toLowerCase();
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryA.CalculationSharingMode__c = sharingMode.toLowerCase();		
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup B';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.RelationShipCriteria__c = condition;
+		rollupSummaryB.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryB.FieldToAggregate__c = aggregateField2;
+		rollupSummaryB.FieldToOrderBy__c = null;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Last.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryB.CalculationSharingMode__c = sharingMode;
+
+		LookupRollupSummary__c rollupSummaryC = new LookupRollupSummary__c();
+		rollupSummaryC.Name = 'Test Rollup C';
+		rollupSummaryC.ParentObject__c = parentObjectName;
+		rollupSummaryC.ChildObject__c = childObjectName;
+		rollupSummaryC.RelationShipField__c = relationshipField;
+		rollupSummaryC.RelationShipCriteria__c = condition;
+		rollupSummaryC.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryC.FieldToAggregate__c = aggregateField3;
+		rollupSummaryC.FieldToOrderBy__c = null;
+		rollupSummaryC.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryC.AggregateResultField__c = aggregateResultField3;
+		rollupSummaryC.Active__c = true;
+		rollupSummaryC.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryC.CalculationSharingMode__c = sharingMode;		
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB, rollupSummaryC };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField1, 'lemon');
+			// aggregateField2 is same SObjectField as aggregateField1
+			child1.put(aggregateField3, 'Red');			
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField1, 'pear');
+			// aggregateField2 is same SObjectField as aggregateField1
+			child2.put(aggregateField3, 'Yellow');			
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField1, 'apple');
+			// aggregateField2 is same SObjectField as aggregateField1
+			child3.put(aggregateField3, 'Blue');			
+			children.add(child3);
+		}
+
+		// Sample various limits prior to an insert
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		// insert child records
+		insert children;
+
+		// Assert limits
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup A
+		// + One query on LookupChild__c for rollup B and for rollup C
+		System.assertEquals(beforeQueries + 3, Limits.getQueries());	
+		
+		// + Three rows for Rollup object
+		// + Nine rows for LookupChild__c for rollup A
+		// + Nine rows for LookupChild__c for rollup B and for rollup C
+		System.assertEquals(beforeRows + 21, Limits.getQueryRows());
+
+		// + Nine rows for LookupChild__c (from the insert statement itself)
+		// + Three rows for LookupParent__c for rollup A & B & C (DLRS combined updates to identical master ids)
+		System.assertEquals(beforeDMLRows + 12, Limits.getDMLRows());		
+
+		// Assert rollups
+		// Note that we are not able to reliably assert rollups B & C because they do not have orderby specified
+		// and will share a context.  Since more than one field will be involved in context no orderby will be applied beyond
+		// the RelationshipField__c
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultField1, aggregateResultField2, parentObjectName })));
+		System.assertEquals('apple', (String) assertParents.get(parentA.id).get(aggregateResultField1));
+		System.assertEquals('apple', (String) assertParents.get(parentB.id).get(aggregateResultField1));
+		System.assertEquals('apple', (String) assertParents.get(parentC.id).get(aggregateResultField1));
+	}
+
+	/**
+	 *	Test for issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/239
+	 *	Three similar rollups differing by:
+	 *		- Different AggregateOperation__c (both use Query rollup - First/Last)
+	 *		- Different AggregateResultField__c
+	 *		- Different Order By two that have no order by specified
+	 *		- Effective values for all other fields same differing only by case used
+	 *	Should result in Two (2) contexts used, two SOQL for the rollup itself and 3 DML rows (1 for each 
+	 *		parent - DLRS combines updates to identical master record ids)
+	 **/	 
+	private testmethod static void testLimitsAndContextsUsedMultipleQueryRollupsNoOrderByShareSingleContext()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField1 = LookupChild__c.Description__c.getDescribe().getName();
+		String aggregateField2 = LookupChild__c.Description2__c.getDescribe().getName();
+		String aggregateField3 = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateField4 = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateField5 = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField1 = LookupParent__c.Descriptions__c.getDescribe().getName();
+		String aggregateResultField2 = LookupParent__c.Descriptions2__c.getDescribe().getName();
+		String aggregateResultField3 = LookupParent__c.Colours__c.getDescribe().getName();
+		String aggregateResultField4 = LookupParent__c.Total__c.getDescribe().getName();
+		String aggregateResultField5 = LookupParent__c.Total2__c.getDescribe().getName();
+		String condition = 'Description__c != null';
+		String relationshipCriteriaFields = 'Description__c';
+		String sharingMode = LREngine.SharingMode.User.name();
+		String fieldToOrderBy = null;
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup A';
+		rollupSummaryA.ParentObject__c = parentObjectName.toLowerCase();
+		rollupSummaryA.ChildObject__c = childObjectName.toLowerCase();
+		rollupSummaryA.RelationShipField__c = relationshipField.toLowerCase();
+		rollupSummaryA.RelationShipCriteria__c = condition;
+		rollupSummaryA.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryA.FieldToAggregate__c = aggregateField1.toLowerCase();
+		rollupSummaryA.FieldToOrderBy__c = fieldToOrderBy;
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultField1.toLowerCase();
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryA.CalculationSharingMode__c = sharingMode.toLowerCase();		
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup B';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.RelationShipCriteria__c = condition;
+		rollupSummaryB.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryB.FieldToAggregate__c = aggregateField2;
+		rollupSummaryB.FieldToOrderBy__c = fieldToOrderBy;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Last.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryB.CalculationSharingMode__c = sharingMode;
+
+		LookupRollupSummary__c rollupSummaryC = new LookupRollupSummary__c();
+		rollupSummaryC.Name = 'Test Rollup C';
+		rollupSummaryC.ParentObject__c = parentObjectName;
+		rollupSummaryC.ChildObject__c = childObjectName;
+		rollupSummaryC.RelationShipField__c = relationshipField;
+		rollupSummaryC.RelationShipCriteria__c = condition;
+		rollupSummaryC.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryC.FieldToAggregate__c = aggregateField3;
+		rollupSummaryC.FieldToOrderBy__c = fieldToOrderBy;
+		rollupSummaryC.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryC.AggregateResultField__c = aggregateResultField3;
+		rollupSummaryC.Active__c = true;
+		rollupSummaryC.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryC.CalculationSharingMode__c = sharingMode;	
+
+		LookupRollupSummary__c rollupSummaryD = new LookupRollupSummary__c();
+		rollupSummaryD.Name = 'Test Rollup D';
+		rollupSummaryD.ParentObject__c = parentObjectName;
+		rollupSummaryD.ChildObject__c = childObjectName;
+		rollupSummaryD.RelationShipField__c = relationshipField;
+		rollupSummaryD.RelationShipCriteria__c = condition;
+		rollupSummaryD.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryD.FieldToAggregate__c = aggregateField4;
+		rollupSummaryD.FieldToOrderBy__c = fieldToOrderBy;
+		rollupSummaryD.AggregateOperation__c = RollupSummaries.AggregateOperation.Last.name();
+		rollupSummaryD.AggregateResultField__c = aggregateResultField4;
+		rollupSummaryD.Active__c = true;
+		rollupSummaryD.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryD.CalculationSharingMode__c = sharingMode;	
+
+		LookupRollupSummary__c rollupSummaryE = new LookupRollupSummary__c();
+		rollupSummaryE.Name = 'Test Rollup E';
+		rollupSummaryE.ParentObject__c = parentObjectName;
+		rollupSummaryE.ChildObject__c = childObjectName;
+		rollupSummaryE.RelationShipField__c = relationshipField;
+		rollupSummaryE.RelationShipCriteria__c = condition;
+		rollupSummaryE.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryE.FieldToAggregate__c = aggregateField5;
+		rollupSummaryE.FieldToOrderBy__c = fieldToOrderBy;
+		rollupSummaryE.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryE.AggregateResultField__c = aggregateResultField5;
+		rollupSummaryE.Active__c = true;
+		rollupSummaryE.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryE.CalculationSharingMode__c = sharingMode;						
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB, rollupSummaryC, rollupSummaryD, rollupSummaryE };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField1, 'lemon');
+			child1.put(aggregateField2, 'tom');
+			child1.put(aggregateField3, 'Red');
+			child1.put(aggregateField4, 42);			
+			// aggregateField5 is same SObjectField as aggregateField4
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField1, 'pear');
+			child2.put(aggregateField2, 'charlie');
+			child2.put(aggregateField3, 'Yellow');
+			child2.put(aggregateField4, 42);
+			// aggregateField5 is same SObjectField as aggregateField4
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField1, 'apple');
+			child3.put(aggregateField2, 'samantha');
+			child3.put(aggregateField3, 'Blue');
+			child3.put(aggregateField4, 42);
+			// aggregateField5 is same SObjectField as aggregateField4
+			children.add(child3);
+		}
+
+		// Sample various limits prior to an insert
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		// insert child records
+		insert children;
+
+		// Assert limits
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup A, B, C, D & E
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
+		
+		// + Five rows for Rollup object
+		// + Nine rows for LookupChild__c for rollup A, B, C, D & E
+		System.assertEquals(beforeRows + 14, Limits.getQueryRows());
+
+		// + Nine rows for LookupChild__c (from the insert statement itself)
+		// + Three rows for LookupParent__c for rollup A & B & C & D & E (DLRS combined updates to identical master ids)
+		System.assertEquals(beforeDMLRows + 12, Limits.getDMLRows());		
+
+		// Assert rollups
+		// Note that we are not able to reliably assert rollups A, B, C, D & E because they do not have orderby specified
+		// and will share a context.  Since more than one field will be involved in context no orderby will be applied beyond
+		// the RelationshipField__c
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultField1, aggregateResultField2, parentObjectName })));
+		System.assertEquals(parents.size(), assertParents.size());
+	}	
+
+	/**
 	 *	Test for issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/216
 	 *	Two similar rollups differing by:
 	 *		- Different AggregateOperation__c (both use Query rollup - First/Last)

--- a/rolluptool/src/classes/RollupServiceTest4.cls
+++ b/rolluptool/src/classes/RollupServiceTest4.cls
@@ -915,7 +915,8 @@ private class RollupServiceTest4 {
 		String condition = 'Amount__c > 1';
 		String relationshipCriteriaFields = 'Amount__c';
 		String sharingMode = LREngine.SharingMode.User.name();
-		String fieldToOrderBy = LookupChild__c.Amount__c.getDescribe().getName();
+		String fieldToOrderBy1 = LookupChild__c.Amount__c.getDescribe().getName();
+		String fieldToOrderBy2 = LookupChild__c.Name.getDescribe().getName();
 
 		// Configure rollups
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
@@ -926,7 +927,7 @@ private class RollupServiceTest4 {
 		rollupSummaryA.RelationShipCriteria__c = condition;
 		rollupSummaryA.RelationShipCriteriaFields__c = relationshipCriteriaFields;
 		rollupSummaryA.FieldToAggregate__c = aggregateField1.toLowerCase();
-		rollupSummaryA.FieldToOrderBy__c = fieldToOrderBy.toLowerCase();
+		rollupSummaryA.FieldToOrderBy__c = fieldToOrderBy1.toLowerCase();
 		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
 		rollupSummaryA.AggregateResultField__c = aggregateResultField1.toLowerCase();
 		rollupSummaryA.Active__c = true;
@@ -941,7 +942,140 @@ private class RollupServiceTest4 {
 		rollupSummaryB.RelationShipCriteria__c = condition;
 		rollupSummaryB.RelationShipCriteriaFields__c = relationshipCriteriaFields;
 		rollupSummaryB.FieldToAggregate__c = aggregateField2;
-		rollupSummaryB.FieldToOrderBy__c = null;
+		rollupSummaryB.FieldToOrderBy__c = fieldToOrderBy2;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Last.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryB.CalculationSharingMode__c = sharingMode;
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField1, 'Red');			
+			child1.put(aggregateField2, 42);
+			child1.put('Name', 'ChildZ');
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField1, 'Yellow');
+			child2.put(aggregateField2, 15);
+			child1.put('Name', 'ChildY');			
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField1, 'Blue');			
+			child3.put(aggregateField2, 10);
+			child1.put('Name', 'ChildX');			
+			children.add(child3);
+		}
+
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		insert children;
+
+		// Assert limits
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup A
+		// + One query on LookupChild__c for rollup B
+		System.assertEquals(beforeQueries + 3, Limits.getQueries());	
+		
+		// + Two rows for Rollup object
+		// + Nine rows for LookupChild__c for rollup A
+		// + Nine rows for LookupChild__c for rollup B
+		System.assertEquals(beforeRows + 20, Limits.getQueryRows());
+
+		// + Nine rows for LookupChild__c (from the update statement itself)
+		// + Three rows for LookupParent__c for rollup A & B (DLRS combined updates to identical master ids)
+		System.assertEquals(beforeDMLRows + 12, Limits.getDMLRows());		
+
+		// Assert rollups
+		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultField1, aggregateResultField2, parentObjectName })));
+		System.assertEquals('Blue', (String) assertParents.get(parentA.id).get(aggregateResultField1));
+		System.assertEquals(42, (Decimal) assertParents.get(parentA.id).get(aggregateResultField2));
+
+		System.assertEquals('Blue', (String) assertParents.get(parentB.id).get(aggregateResultField1));
+		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField2));
+
+		System.assertEquals('Blue', (String) assertParents.get(parentC.id).get(aggregateResultField1));
+		System.assertEquals(42, (Decimal) assertParents.get(parentC.id).get(aggregateResultField2));
+	}
+
+	/**
+	 *	Test for issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/216
+	 *	Two similar rollups differing by:
+	 *		- Different AggregateOperation__c (both use Query rollup - First/Last)
+	 *		- Different AggregateResultField__c
+	 *		- Different Order By each containing multiple fields
+	 *		- Effective values for all other fields same differing only by case used
+	 *	Should result in Two (2) contexts used, two SOQL for the rollup itself and 3 DML rows (1 for each 
+	 *		parent - DLRS combines updates to identical master record ids)
+	 **/
+	private testmethod static void testLimitsAndContextsUsedMultipleQueryRollupsDifferByOperationFieldCaseMultipleFieldsOrderBy()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField1 = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateField2 = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField1 = LookupParent__c.Colours__c.getDescribe().getName();
+		String aggregateResultField2 = LookupParent__c.Total2__c.getDescribe().getName();
+		String condition = 'Amount__c > 1';
+		String relationshipCriteriaFields = 'Amount__c';
+		String sharingMode = LREngine.SharingMode.User.name();
+		String orderBy1 = 'Amount__c ASC NULLS FIRST, Color__c ASC NULLS FIRST';
+		String orderBy2 = 'Amount__c ASC NULLS FIRST, Color__c DESC NULLS FIRST';
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup A';
+		rollupSummaryA.ParentObject__c = parentObjectName.toLowerCase();
+		rollupSummaryA.ChildObject__c = childObjectName.toLowerCase();
+		rollupSummaryA.RelationShipField__c = relationshipField.toLowerCase();
+		rollupSummaryA.RelationShipCriteria__c = condition;
+		rollupSummaryA.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryA.FieldToAggregate__c = aggregateField1.toLowerCase();
+		rollupSummaryA.FieldToOrderBy__c = orderBy1;
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultField1.toLowerCase();
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryA.CalculationSharingMode__c = sharingMode.toLowerCase();		
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup B';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.RelationShipCriteria__c = condition;
+		rollupSummaryB.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryB.FieldToAggregate__c = aggregateField2;
+		rollupSummaryB.FieldToOrderBy__c = orderBy2;
 		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Last.name();
 		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
 		rollupSummaryB.Active__c = true;
@@ -1017,6 +1151,125 @@ private class RollupServiceTest4 {
 	}
 
 	/**
+	 *	Test for issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/239
+	 *	Two similar rollups differing by:
+	 *		- Different AggregateOperation__c (both use Query rollup - First/Last)
+	 *		- Different AggregateResultField__c
+	 *		- Neither rollup has any Order by specified (this will result in non-deterministic rolled up values)
+	 *		- Effective values for all other fields same differing only by case used
+	 *	Should result in a single context used, a single SOQL for the rollup itself and 3 DML rows (1 for each parent)
+	 **/
+	private testmethod static void testLimitsAndContextsUsedMultipleQueryRollupsDifferByOperationFieldAndCaseSameCriteriaSameCaseNoOrderBy()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+
+		Schema.SObjectType parentType = LookupParent__c.sObjectType;
+		Schema.SObjectType childType = LookupChild__c.sObjectType;
+		String parentObjectName = parentType.getDescribe().getName();
+		String childObjectName = childType.getDescribe().getName();
+		String relationshipField = LookupChild__c.LookupParent__c.getDescribe().getName();
+		String aggregateField1 = LookupChild__c.Color__c.getDescribe().getName();
+		String aggregateField2 = LookupChild__c.Amount__c.getDescribe().getName();
+		String aggregateResultField1 = LookupParent__c.Colours__c.getDescribe().getName();
+		String aggregateResultField2 = LookupParent__c.Total2__c.getDescribe().getName();
+		String condition = 'Amount__c > 1';
+		String relationshipCriteriaFields = 'Amount__c';
+		String sharingMode = LREngine.SharingMode.User.name();
+		String fieldToOrderBy = null;
+
+		// Configure rollups
+		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
+		rollupSummaryA.Name = 'Test Rollup A';
+		rollupSummaryA.ParentObject__c = parentObjectName.toLowerCase();
+		rollupSummaryA.ChildObject__c = childObjectName.toLowerCase();
+		rollupSummaryA.RelationShipField__c = relationshipField.toLowerCase();
+		rollupSummaryA.RelationShipCriteria__c = condition;
+		rollupSummaryA.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryA.FieldToAggregate__c = aggregateField1.toLowerCase();
+		rollupSummaryA.FieldToOrderBy__c = fieldToOrderBy;
+		rollupSummaryA.AggregateOperation__c = RollupSummaries.AggregateOperation.First.name();
+		rollupSummaryA.AggregateResultField__c = aggregateResultField1.toLowerCase();
+		rollupSummaryA.Active__c = true;
+		rollupSummaryA.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryA.CalculationSharingMode__c = sharingMode.toLowerCase();		
+
+		LookupRollupSummary__c rollupSummaryB = new LookupRollupSummary__c();
+		rollupSummaryB.Name = 'Test Rollup B';
+		rollupSummaryB.ParentObject__c = parentObjectName;
+		rollupSummaryB.ChildObject__c = childObjectName;
+		rollupSummaryB.RelationShipField__c = relationshipField;
+		rollupSummaryB.RelationShipCriteria__c = condition;
+		rollupSummaryB.RelationShipCriteriaFields__c = relationshipCriteriaFields;
+		rollupSummaryB.FieldToAggregate__c = aggregateField2;
+		rollupSummaryB.FieldToOrderBy__c = fieldToOrderBy;
+		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Last.name();
+		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
+		rollupSummaryB.Active__c = true;
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
+		rollupSummaryB.CalculationSharingMode__c = sharingMode;
+
+		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
+		insert rollups;
+		
+		// Insert parents
+		SObject parentA = parentType.newSObject();
+		parentA.put('Name', 'ParentA');
+		SObject parentB = parentType.newSObject();
+		parentB.put('Name', 'ParentB');
+		SObject parentC = parentType.newSObject();
+		parentC.put('Name', 'ParentC');
+		List<SObject> parents = new List<SObject> { parentA, parentB, parentC };
+		insert parents;
+
+		// Insert children
+		List<SObject> children = new List<SObject>();
+		for(SObject parent : parents)
+		{
+			SObject child1 = childType.newSObject();
+			child1.put(relationshipField, parent.Id);
+			child1.put(aggregateField1, 'orange');			
+			child1.put(aggregateField2, 42);
+			children.add(child1);
+			SObject child2 = childType.newSObject();
+			child2.put(relationshipField, parent.Id);
+			child2.put(aggregateField1, 'purple');
+			child2.put(aggregateField2, 15);
+			children.add(child2);
+			SObject child3 = childType.newSObject();
+			child3.put(relationshipField, parent.Id);
+			child3.put(aggregateField1, 'cyan');			
+			child3.put(aggregateField2, 10);
+			children.add(child3);
+		}
+
+		// Sample various limits prior to an update
+		Integer beforeQueries = Limits.getQueries();
+		Integer beforeRows = Limits.getQueryRows();
+		Integer beforeDMLRows = Limits.getDMLRows();
+
+		insert children;
+
+		// Assert limits
+		// + One query on Rollup object
+		// + One query on LookupChild__c for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
+		
+		// + Two rows for Rollup object
+		// + Nine rows for LookupChild__c
+		System.assertEquals(beforeRows + 11, Limits.getQueryRows());
+
+		// + Nine rows for LookupChild__c (from the update statement itself)
+		// + Three rows for LookupParent__c (from rollup processing)
+		System.assertEquals(beforeDMLRows + 12, Limits.getDMLRows());		
+
+		// Unable to reliably assert rollups in this test because
+		// no order by was specified therefore result is non-deterministic
+		// this test is focused on limits and contexts to ensure a single context is used
+	}	
+
+	/**
 	 *	Test for issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/229
 	 *	Ensure that any field on LookupRollupSummary__c that is describable is updated with describe info
 	 **/
@@ -1037,7 +1290,7 @@ private class RollupServiceTest4 {
 		String condition = 'Amount__c > 1';
 		List<String> relationshipCriteriaFields = new List<String> { 'Amount__c', 'Name', 'Id', 'IsDeleted' };
 		String sharingMode = LREngine.SharingMode.User.name();
-		String fieldToOrderBy = LookupChild__c.Amount__c.getDescribe().getName();
+		String fieldToOrderBy = 'Amount__c,Color__c ASC,Name NULLS LAST,Id DESC NULLS FIRST';
 
 		// Configure rollups
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();

--- a/rolluptool/src/classes/RollupServiceTest5.cls
+++ b/rolluptool/src/classes/RollupServiceTest5.cls
@@ -219,4 +219,334 @@ private class RollupServiceTest5 {
 		System.assertEquals(1, [select AnnualRevenue from Account where id = :accountParent.Id][0].AnnualRevenue);
 		System.assertEquals(null, [select TotalOpportunityQuantity from Opportunity where id = :oppParent.Id][0].TotalOpportunityQuantity);		
 	}	
+
+	private static void assertOrdering(List<Utilities.Ordering> order, Integer numFields, List<String> fields, List<Utilities.SortOrder> directions, List<Boolean> nullsLast)
+	{
+		System.assertNotEquals(null, order);
+		System.assertEquals(numFields, order.size());
+		for (Integer i = 0; i < numFields; i++)
+		{
+			assertOrdering(order[i], fields[i], directions[i], nullsLast[i]);
+		}
+	}
+
+    private static void assertOrdering(Utilities.Ordering o, String field, Utilities.SortOrder direction, Boolean nullsLast)
+    {
+        System.assertEquals(field, o.getField());
+        System.assertEquals(direction, o.getDirection());
+        System.assertEquals(nullsLast, o.getNullsLast());
+    }
+
+	@IsTest
+	private static void testParseOrderByFieldOnly() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}
+
+	@IsTest
+	private static void testParseOrderByFieldOnlyLowered() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('amount__c');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldOnlyMixedCase() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('aMoUnT__c');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'aMoUnT__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndASCDirection() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndASCDirectionLowered() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c asc');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndDESCDirection() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c DESC');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.DESCENDING },
+						new List<Boolean> { false });
+	}
+
+	@IsTest
+	private static void testParseOrderByFieldAndDESCDirectionLowered() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c desc');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.DESCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndNullsFirst() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c NULLS FIRST');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndNullsFirstLowered() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c nulls first');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndNullsLast() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c NULLS LAST');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { true });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndNullsLastLowered() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c nulls last');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { true });
+	}		
+
+	@IsTest
+	private static void testParseOrderByFieldAndASCDirectionAndNullsFirst() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC NULLS FIRST');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndASCDirectionAndNullsLast() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC NULLS LAST');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { true });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndDESCDirectionAndNullsFirst() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c DESC NULLS FIRST');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.DESCENDING },
+						new List<Boolean> { false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByFieldAndDESCDirectionAndNullsLast() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c DESC NULLS LAST');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'Amount__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.DESCENDING },
+						new List<Boolean> { true });
+	}		
+
+	@IsTest
+	private static void testParseOrderByMultipleFieldOnly() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c, Color__c, Name');
+		assertOrdering(	order, 
+						3, 
+						new List<String> { 'Amount__c', 'Color__c', 'Name' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING, Utilities.SortOrder.ASCENDING, Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false, false, false });
+	}
+
+	@IsTest
+	private static void testParseOrderByMultipleFieldAndMixedDirection() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC, Color__c DESC, Name ASC');
+		assertOrdering(	order, 
+						3, 
+						new List<String> { 'Amount__c', 'Color__c', 'Name' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING, Utilities.SortOrder.DESCENDING, Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false, false, false });
+	}	
+
+	@IsTest
+	private static void testParseOrderByMultipleFieldAndMixedDirectionAndNulls() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC NULLS LAST, Color__c DESC NULLS FIRST, Name ASC NULLS LAST');
+		assertOrdering(	order, 
+						3, 
+						new List<String> { 'Amount__c', 'Color__c', 'Name' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING, Utilities.SortOrder.DESCENDING, Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { true, false, true });
+	}
+
+	@IsTest
+	private static void testParseOrderByBadField() {
+		// parsing will succeed - validation of field name is done in RollupSummaries
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('BadField__c');
+		assertOrdering(	order, 
+						1, 
+						new List<String> { 'BadField__c' },
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING },
+						new List<Boolean> { false });
+	}
+
+	@IsTest
+	private static void testParseOrderByBadDirection() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c BAD');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void testParseOrderByBadNulls() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC BAD');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void testParseOrderByMissingNulls() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC LAST');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}	
+
+	@IsTest
+	private static void testParseOrderByBadNullsType() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC NULLS BAD');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void testParseOrderByMissingNullsType() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC NULLS');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}	
+
+	@IsTest
+	private static void testParseOrderByInvalidStart() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('BAD Amount__c ASC NULLS FIRST');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void testParseOrderByInvalidMiddle() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC BAD NULLS FIRST');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}	
+
+	@IsTest
+	private static void testParseOrderByInvalidEnd() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC NULLS FIRST BAD');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void testParseOrderByMultipleSecondFieldInvalid() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC NULLS FIRST, Color__c ASC NULLS BAD, Name ASC NULLS FIRST');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}
+
+	@IsTest
+	private static void testParseOrderByMultipleThirdFieldInvalid() {
+		try {
+			List<Utilities.Ordering> order = Utilities.parseOrderByClause('Amount__c ASC NULLS FIRST, Color__c ASC NULLS LAST, Name ASC FIRST');
+			System.assert(false, 'Expected exception');
+		} catch(Utilities.OrderByInvalidException e) {
+			System.assertEquals('Invalid order by clause.', e.getMessage());
+		}
+	}	
+
+	@IsTest
+	private static void testParseOrderByMultipleFieldWhitespaceEverywhere() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause('  	           Amount__c      		ASC        	 NULLS       	 LAST      ,   	Color__c	  DESC    NULLS      FIRST        	');
+		assertOrdering(	order, 
+						2, 
+						new List<String> { 'Amount__c', 'Color__c'},
+						new List<Utilities.SortOrder> { Utilities.SortOrder.ASCENDING, Utilities.SortOrder.DESCENDING },
+						new List<Boolean> { true, false});
+	}
+
+	@IsTest
+	private static void testParseOrderByBlankClause() {
+		List<Utilities.Ordering> order = Utilities.parseOrderByClause(null);
+		System.assertEquals(null, order);
+
+		order = Utilities.parseOrderByClause('');
+		System.assertEquals(null, order);	
+
+		order = Utilities.parseOrderByClause('		 	   ');
+		System.assertEquals(null, order);
+	}					
 }

--- a/rolluptool/src/classes/RollupSummaries.cls
+++ b/rolluptool/src/classes/RollupSummaries.cls
@@ -131,7 +131,6 @@ public class RollupSummaries extends fflib_SObjectDomain
 			// Child Object fields
 			SObjectField relationshipField = null;
 			SObjectField fieldToAggregate = null;
-			SObjectField fieldToOrderBy = null;
 			Map<String, Schema.SObjectField> childObjectFields = gdFields.get(childObjectType);
 			if(childObjectFields!=null)
 			{
@@ -145,9 +144,12 @@ public class RollupSummaries extends fflib_SObjectDomain
 					lookupRollupSummary.FieldToAggregate__c = fieldToAggregate.getDescribe().getName();
 				// Field to Order By
 				if(lookupRollupSummary.FieldToOrderBy__c!=null) {
-					fieldToOrderBy = childObjectFields.get(lookupRollupSummary.FieldToOrderBy__c);
-					if(fieldToOrderBy!=null)
-						lookupRollupSummary.FieldToOrderBy__c = fieldToOrderBy.getDescribe().getName();
+					try {
+		                lookupRollupSummary.FieldToOrderBy__c = parseOrderByClause(lookupRollupSummary.FieldToOrderBy__c, childObjectFields);
+					} catch(Utilities.OrderByInvalidException e) {
+						// there is a problem with order by so we ignore it intentionally here since we're just trying 
+						// to update field names with describe info.  The error will be caught during validation phase.
+					}
 				}
 			}
 			// Parent Object fields
@@ -212,7 +214,7 @@ public class RollupSummaries extends fflib_SObjectDomain
 			// Child Object fields valid?
 			SObjectField relationshipField = null;
 			SObjectField fieldToAggregate = null;
-			SObjectField fieldToOrderBy = null;
+			Boolean orderByIsValid = true;
 			Map<String, Schema.SObjectField> childObjectFields = gdFields.get(childObjectType);
 			if(childObjectFields!=null)
 			{
@@ -225,10 +227,13 @@ public class RollupSummaries extends fflib_SObjectDomain
 				if(fieldToAggregate==null)
 					lookupRollupSummary.FieldToAggregate__c.addError(error('Field does not exist.', lookupRollupSummary, LookupRollupSummary__c.FieldToAggregate__c));
 				// Field to Order By valid?
-				if(lookupRollupSummary.FieldToOrderBy__c!=null) {
-					fieldToOrderBy = childObjectFields.get(lookupRollupSummary.FieldToOrderBy__c);
-					if(fieldToOrderBy==null)
-						lookupRollupSummary.FieldToOrderBy__c.addError(error('Field does not exist.', lookupRollupSummary, LookupRollupSummary__c.FieldToOrderBy__c));					
+				if(!String.isBlank(lookupRollupSummary.FieldToOrderBy__c)) {
+					try {
+						String orderByClause = parseOrderByClause(lookupRollupSummary.FieldToOrderBy__c, childObjectFields);
+					} catch(Utilities.OrderByInvalidException e) {
+						orderByIsValid = false;
+						lookupRollupSummary.FieldToOrderBy__c.addError(error(e.getMessage(), lookupRollupSummary, LookupRollupSummary__c.FieldToOrderBy__c));
+					}
 				}
 				// TODO: Validate relationship field is a lookup to the parent
 				// ...
@@ -273,19 +278,20 @@ public class RollupSummaries extends fflib_SObjectDomain
 				   childObjectType!=null &&
 				   relationshipField!=null &&
 				   aggregateResultField!=null &&
-				   fieldToAggregate!=null)
+				   fieldToAggregate!=null &&
+				   orderByIsValid)
 				{
 					// Validate via LREngine context
 					LREngine.Context lreContext = new LREngine.Context(
 						parentObjectType, // parent object
 		                childObjectType,  // child object
 		                relationshipField.getDescribe(), // relationship field name
-		                lookupRollupSummary.RelationShipCriteria__c); 
+		                lookupRollupSummary.RelationShipCriteria__c,
+		                lookupRollupSummary.FieldToOrderBy__c); 
 					lreContext.add(
 			            new LREngine.RollupSummaryField(
 							aggregateResultField.getDescribe(),
 							fieldToAggregate.getDescribe(),
-							fieldToOrderBy!=null ? fieldToOrderBy.getDescribe() : null, // optional field to order by
 							OPERATION_PICKLIST_TO_ENUMS.get(lookupRollupSummary.AggregateOperation__c),
 							lookupRollupSummary.ConcatenateDelimiter__c));
 					// Validate the SOQL
@@ -386,5 +392,31 @@ public class RollupSummaries extends fflib_SObjectDomain
 			componentName = prefix + trimmedObjectName + suffix;
 		}
 		return componentName;
+	}
+
+	private static String parseOrderByClause(String orderByClause, Map<String, SObjectField> fields)
+	{
+		List<Utilities.Ordering> fieldsToOrderBy = Utilities.parseOrderByClause(orderByClause);
+		if (fieldsToOrderBy == null || fieldsToOrderBy.isEmpty()) {
+			return null;
+		}
+
+		String parsedOrderByClause = '';
+        for (Utilities.Ordering orderByField :fieldsToOrderBy) {
+        	SObjectField sObjectField = fields.get(orderByField.getField());
+        	if (sObjectField == null) {
+        		throw new Utilities.OrderByInvalidException('Field does not exist.');
+        	}
+        	// update name with describe info
+        	orderByField.setField(sObjectField.getDescribe().getName());
+
+        	// using toAsSpecifiedString so that we update the field name to proper describe info
+        	// but leave the rest of what was input unchanged.  If we called toString() we would 
+        	// add fully qualified Order By Clause and we don't want to add in portions of the clause
+        	// that the user didn't provide in the first place.
+        	parsedOrderByClause += (String.isBlank(parsedOrderByClause) ? '' : ',') + orderByField.toAsSpecifiedString();
+        }
+
+        return parsedOrderByClause;
 	}
 }

--- a/rolluptool/src/classes/RollupSummariesTest.cls
+++ b/rolluptool/src/classes/RollupSummariesTest.cls
@@ -294,7 +294,32 @@ private class RollupSummariesTest
 		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());	
 		System.assertEquals('Field does not exist.', fflib_SObjectDomain.Errors.getAll()[0].message);
 		System.assertEquals(LookupRollupSummary__c.FieldToOrderBy__c, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field);
-	}		
+	}
+
+	private testmethod static void testInsertFieldToOrderByInvalidClauseValidation()
+	{
+		// Test supported?
+		if(!TestContext.isSupported())
+			return;
+		
+		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
+		rollupSummary.Name = 'Total Opportunities into Annual Revenue on Account';
+		rollupSummary.ParentObject__c = 'Account';
+		rollupSummary.ChildObject__c = 'Opportunity';
+		rollupSummary.RelationShipField__c = 'AccountId';
+		rollupSummary.RelationShipCriteria__c = null;
+		rollupSummary.FieldToAggregate__c = 'Amount';
+		rollupSummary.FieldToOrderBy__c = 'Amount ASC NULLS BAD';
+		rollupSummary.AggregateOperation__c = 'Sum';
+		rollupSummary.AggregateResultField__c = 'AnnualRevenue';
+		rollupSummary.Active__c = true;
+		rollupSummary.CalculationMode__c = 'Realtime';
+		fflib_SObjectDomain.Test.Database.onInsert(new LookupRollupSummary__c[] { rollupSummary } );		
+		fflib_SObjectDomain.triggerHandler(RollupSummaries.class);		
+		System.assertEquals(1, fflib_SObjectDomain.Errors.getAll().size());	
+		System.assertEquals('Invalid order by clause.', fflib_SObjectDomain.Errors.getAll()[0].message);
+		System.assertEquals(LookupRollupSummary__c.FieldToOrderBy__c, ((fflib_SObjectDomain.FieldError)fflib_SObjectDomain.Errors.getAll()[0]).field);
+	}			
 	
 	private testmethod static void testInsertAggregateResultFieldValidation()
 	{

--- a/rolluptool/src/classes/TestLREngine.cls
+++ b/rolluptool/src/classes/TestLREngine.cls
@@ -931,6 +931,28 @@ private class TestLREngine {
         System.assertEquals('Won', reloadedAcc2.get(rollupField2.master.getName()));                
     }
 
+    static testMethod void testIsAggregateOrQueryBasedRollup()
+    {
+        // map of operations with flag indicating if it is an aggregate operation
+        Map<LREngine.RollupOperation, Boolean> operations = new Map<LREngine.RollupOperation, Boolean> {
+                                                        LREngine.RollupOperation.Sum => true,
+                                                        LREngine.RollupOperation.Min => true,
+                                                        LREngine.RollupOperation.Max => true,
+                                                        LREngine.RollupOperation.Avg => true,
+                                                        LREngine.RollupOperation.Count => true,
+                                                        LREngine.RollupOperation.Count_Distinct => true,
+                                                        LREngine.RollupOperation.Concatenate => false,
+                                                        LREngine.RollupOperation.Concatenate_Distinct => false,
+                                                        LREngine.RollupOperation.First => false,
+                                                        LREngine.RollupOperation.Last => false
+                                                };
+        for (LREngine.RollupOperation op :operations.keySet()) {
+            Boolean isAggregate = operations.get(op);
+            System.assertEquals(isAggregate, LREngine.isAggregateBasedRollup(op));
+            System.assertEquals(!isAggregate, LREngine.isQueryBasedRollup(op));
+        }
+    }
+
     static private void testRollup(String detailOrderByClause, LREngine.RollupSummaryField rollupField, String expected1, String expected2) {
         prepareData();
 

--- a/rolluptool/src/classes/TestLREngine.cls
+++ b/rolluptool/src/classes/TestLREngine.cls
@@ -33,10 +33,12 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 @isTest
 private class TestLREngine {
 		// common master records for the test case
-		static Account acc1, acc2;
+		static Account acc1, acc2, acc3, acc4;
 		// common bunch of detail records for the test case
 		static Opportunity[] detailRecords;
+        static Opportunity[] detailRecords2;
 		static Opportunity[] detailRecordsAcc1;
+        static Opportunity[] detailRecordsAcc3;
 		// dynamic reference to this field to avoid it being included in the package
 		static Schema.SObjectField ACCOUNT_SLA_EXPIRATION_DATE;
 		static Schema.SObjectField ACCOUNT_NUMBER_OF_EMPLOYEES;
@@ -131,7 +133,76 @@ private class TestLREngine {
                     detailRecord.put(ANNUALIZED_RECCURING_REVENUE, 1000);
 	         detailRecordsAcc1 = new Opportunity[] {o1Acc1, o2Acc1, o3Acc1};
 	         insert detailRecords;			
-		}		
+        }
+
+        /*
+         creates the common seed data using Opportunity and Account objects. 
+         */
+        static void prepareData2() {
+             acc3 =  new Account(Name = 'Acc3');
+             acc4 =  new Account(Name = 'Acc4');
+             insert new Account[] {acc3, acc4};
+               
+             Date today = System.today();
+             Opportunity o1Acc3 = new Opportunity( 
+                                                    Name = 'o1Acc3', 
+                                                    AccountId = acc3.Id,
+                                                    Amount = 100.00,
+                                                    CloseDate = today,
+                                                    Type = 'New Customer',
+                                                    StageName = 'red'
+                                                );
+             Opportunity o2Acc3 = new Opportunity(
+                                                    Name = 'o2Acc3',
+                                                    AccountId = acc3.Id,
+                                                    Amount = 100.00,
+                                                    CloseDate = today,
+                                                    Type = 'New Customer',
+                                                    StageName = 'yellow'
+                                                );
+    
+             Opportunity o3Acc3 = new Opportunity(
+                                                    Name = 'o3Acc3',
+                                                    AccountId = acc3.Id,
+                                                    Amount = null,
+                                                    CloseDate = today,
+                                                    Type = 'New Customer',
+                                                    StageName = 'blue'
+                                                );
+    
+             Opportunity o1Acc4 = new Opportunity(
+                                                    Name = 'o1Acc4',
+                                                    AccountId = acc4.Id,
+                                                    Amount = 100.00,
+                                                    CloseDate = today,
+                                                    Type = 'New Customer',
+                                                    StageName = 'orange'
+                                                );
+             
+             Opportunity o2Acc4 = new Opportunity(
+                                                    Name = 'o2Acc4',
+                                                    AccountId = acc4.Id,
+                                                    Amount = 100.00,
+                                                    CloseDate = today,
+                                                    Type = 'New Customer',
+                                                    StageName = 'green'
+                                                );
+    
+             Opportunity o3Acc4 = new Opportunity(
+                                                    Name = 'o3Acc4',
+                                                    AccountId = acc4.Id,
+                                                    Amount = 100.00,
+                                                    CloseDate = today,
+                                                    Type = 'New Customer',
+                                                    StageName = 'purple'
+                                                );
+             detailRecords2 = new Opportunity[] {o1Acc3, o2Acc3, o3Acc3, o1Acc4, o2Acc4, o3Acc4};
+             if(ANNUALIZED_RECCURING_REVENUE!=null)
+                for(Opportunity detailRecord : detailRecords2)
+                    detailRecord.put(ANNUALIZED_RECCURING_REVENUE, 1000);
+             detailRecordsAcc3 = new Opportunity[] {o1Acc3, o2Acc3, o3Acc3};
+             insert detailRecords2;          
+        }           	
 
 	
 	/*
@@ -672,20 +743,22 @@ private class TestLREngine {
 
     static testMethod void testRollupConcatenateTruncate() {
         testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.AccountNumber,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    null, LREngine.RollupOperation.Concatenate, '01234567890123456789,'),
+                    LREngine.RollupOperation.Concatenate, '01234567890123456789,'),
                 'test01234567890123456789,test01234567...',
                 'Lost01234567890123456789,Won012345678...');
     }    
 
     static testMethod void testRollupConcatenate() {
         testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    null, LREngine.RollupOperation.Concatenate, ','),
+                    LREngine.RollupOperation.Concatenate, ','),
                 'test,test,test',
                 'Lost,Won,Won');
     } 
@@ -693,130 +766,120 @@ private class TestLREngine {
 
     static testMethod void testRollupConcatenateBR() {
         testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    null, LREngine.RollupOperation.Concatenate, 'BR()'),
+                    LREngine.RollupOperation.Concatenate, 'BR()'),
                 'test\ntest\ntest',
                 'Lost\nWon\nWon');
     } 
 
     static testMethod void testRollupConcatenateOrderBy() {
         testRollup(
+            Schema.SObjectType.Opportunity.fields.Amount.getName(),
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    Schema.SObjectType.Opportunity.fields.Amount,
                     LREngine.RollupOperation.Concatenate, ','),
                 'test,test,test',
                 'Won,Won,Lost');
     } 
 
-    /**
-     * Current default behavior of LREngine is to build the order by clause based on the following
-     *    1) LookupField then by 
-     *    2) For each RollupSummaryField in context (in the order specified in the context)
-     *          a) if detailOrderBy is specified use detailOrderBy.getName()
-     *          b) else use detail.getName()
-     *
-     * This results in all queries having an order by even if one is not specified.
-     * Also, results in summary fields after the first having their order by influenced by previous summary fields
-     * 
-     * For example, if two rollup summary fields are in the context as follows:
-     *    1) Order By Amount
-     *    2) Order By CloseDate
-     *
-     * A single SOQL will be executed with an order by of AccountId, Amount, CloseDate
-     */
-    static testMethod void testMultipleRollupsDifferentFieldWithDifferentOrderBy() {
-        // create seed data 
-         prepareData();
-
-        // force the 'Lost' Opportunity to be the oldest to demonstrate that
-        // even when ordering by CloseDate, order by will be based on AccountId, Amount, CloseDate
-        // since summaries are in the same context and context applies order by fields
-        // using "Then By" approach
-        Opportunity makeOldest = [SELECT Id, CloseDate FROM Opportunity WHERE AccountId = :acc2.Id AND Name = 'o2Acc2' LIMIT 1];
-        makeOldest.CloseDate = System.today().addMonths(-24);
-        update makeOldest;
-
-        // assert that the oldest opportunity is the 400 one that we just changed and that its 
-        // stage name is lost
-        Opportunity assertOldest = [SELECT Id, Amount, StageName FROM Opportunity WHERE AccountId = :acc2.Id ORDER BY AccountId,CloseDate LIMIT 1];
-        System.assertEquals(400, assertOldest.Amount);
-        System.assertEquals('Lost', assertOldest.StageName);
-         
-        LREngine.Context ctx = new LREngine.Context(Account.SobjectType, 
-                                                Opportunity.SobjectType, 
-                                                Schema.SObjectType.Opportunity.fields.AccountId);
-         
-        LREngine.RollupSummaryField rollupField1 = 
-            new LREngine.RollupSummaryField(
-                                            Schema.SObjectType.Account.fields.Description,
-                                            Schema.SObjectType.Opportunity.fields.StageName,
-                                            Schema.SObjectType.Opportunity.fields.Amount,
-                                            LREngine.RollupOperation.Concatenate, ','
-                                         ); 
-        ctx.add(rollupField1);
-        LREngine.RollupSummaryField rollupField2 =         
-            new LREngine.RollupSummaryField(
-                                            Schema.SObjectType.Account.fields.Sic,
-                                            Schema.SObjectType.Opportunity.fields.StageName,
-                                            Schema.SObjectType.Opportunity.fields.CloseDate,
-                                            LREngine.RollupOperation.First, null
-                                         );   
-        ctx.add(rollupField2);
-
-        SObject[] masters = LREngine.rollUp(ctx, detailRecords);
-
-        Map<Id, SObject> mastersById = new Map<Id, SObject>(masters);
-        Account reloadedAcc1 = (Account)mastersById.get(acc1.Id);
-        Account reloadedAcc2 = (Account)mastersById.get(acc2.Id);
-        System.assertEquals(2, masters.size());
-        System.assertEquals('test,test,test', reloadedAcc1.get(rollupField1.master.getName()));
-        System.assertEquals('test', reloadedAcc1.get(rollupField2.master.getName()));
-        System.assertEquals('Won,Won,Lost', reloadedAcc2.get(rollupField1.master.getName()));
-        // the oldest is 'Lost' but due to Then By approach, the oldest should be 'Won'
-        System.assertEquals('Won', reloadedAcc2.get(rollupField2.master.getName())); 
-    }     
-
-    static testMethod void testRollupConcatenateNoDelimiter() {
-        testRollup(
+    static testMethod void testRollupConcatenateOrderByMultipleAscendingNullsFirst() {
+        testRollup2(
+            'CloseDate, Type, Amount, Name',
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    null, LREngine.RollupOperation.Concatenate, null),
+                    LREngine.RollupOperation.Concatenate, ','),
+                'blue,red,yellow',
+                'orange,green,purple');
+    } 
+
+    static testMethod void testRollupConcatenateOrderByMultipleAscendingNullsLast() {
+        testRollup2(
+            'CloseDate NULLS LAST, Type NULLS LAST, Amount NULLS LAST, Name NULLS LAST',
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, ','),
+                'red,yellow,blue',
+                'orange,green,purple');
+    }
+
+    static testMethod void testRollupConcatenateOrderByMultipleDescendingNullsFirst() {
+        testRollup2(
+            'CloseDate DESC, Type DESC, Amount DESC, Name DESC',
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, ','),
+                'blue,yellow,red',
+                'purple,green,orange');
+    } 
+
+    static testMethod void testRollupConcatenateOrderByMultipleDescendingNullsLast() {
+        testRollup2(
+            'CloseDate DESC NULLS LAST, Type DESC NULLS LAST, Amount DESC NULLS LAST, Name DESC NULLS LAST',
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, ','),
+                'yellow,red,blue',
+                'purple,green,orange');
+    }
+
+    static testMethod void testRollupConcatenateNoDelimiter() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, null),
                 'testtesttest',
                 'LostWonWon');
     } 
 
     static testMethod void testRollupConcatenateDistinct() {
         testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    null, LREngine.RollupOperation.Concatenate_Distinct, ','),
+                    LREngine.RollupOperation.Concatenate_Distinct, ','),
                 'test',
                 'Lost,Won');
     } 
 
     static testMethod void testRollupConcatenateDistinctWithOrderBy() {
         testRollup(
+            Schema.SObjectType.Opportunity.fields.Amount.getName(),
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    Schema.SObjectType.Opportunity.fields.Amount,
                     LREngine.RollupOperation.Concatenate_Distinct, ','),
                 'test',
                 'Won,Lost');
     } 
 
-    static testMethod void testRollupFirst() {
+    static testMethod void testRollupConcatenateDistinctWithMultipleFieldsOrderBy() {
         testRollup(
+            'Amount DESC, CloseDate DESC, Type DESC, Name DESC',
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    Schema.SObjectType.Opportunity.fields.Amount,
+                    LREngine.RollupOperation.Concatenate_Distinct, ','),
+                'test',
+                'Lost,Won');
+    } 
+
+    static testMethod void testRollupFirst() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.Amount.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
                     LREngine.RollupOperation.First, null),
                 'test',
                 'Won');
@@ -824,10 +887,10 @@ private class TestLREngine {
 
     static testMethod void testRollupLast() {
         testRollup(
+            Schema.SObjectType.Opportunity.fields.Amount.getName(),
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    Schema.SObjectType.Opportunity.fields.Amount,
                     LREngine.RollupOperation.Last, null),
                 'test',
                 'Lost');
@@ -839,20 +902,20 @@ private class TestLREngine {
         LREngine.Context ctx = new LREngine.Context(
             Account.SobjectType, 
             Opportunity.SobjectType, 
-            Schema.SObjectType.Opportunity.fields.AccountId);
+            Schema.SObjectType.Opportunity.fields.AccountId,
+            null,
+            Schema.SObjectType.Opportunity.fields.Amount.getName());
 
         LREngine.RollupSummaryField rollupField1 = 
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Description,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    Schema.SObjectType.Opportunity.fields.Amount,
                     LREngine.RollupOperation.Last, null);
         ctx.add(rollupField1);
         LREngine.RollupSummaryField rollupField2 =         
             new LREngine.RollupSummaryField(
                     Schema.SObjectType.Account.fields.Sic,
                     Schema.SObjectType.Opportunity.fields.StageName,
-                    Schema.SObjectType.Opportunity.fields.Amount,
                     LREngine.RollupOperation.First, null);
         ctx.add(rollupField2);
 
@@ -868,14 +931,15 @@ private class TestLREngine {
         System.assertEquals('Won', reloadedAcc2.get(rollupField2.master.getName()));                
     }
 
-    static private void testRollup(LREngine.RollupSummaryField rollupField, String expected1, String expected2) {
-
+    static private void testRollup(String detailOrderByClause, LREngine.RollupSummaryField rollupField, String expected1, String expected2) {
         prepareData();
 
         LREngine.Context ctx = new LREngine.Context(
             Account.SobjectType, 
             Opportunity.SobjectType, 
-            Schema.SObjectType.Opportunity.fields.AccountId);
+            Schema.SObjectType.Opportunity.fields.AccountId,
+            null, // detailWhereClause
+            detailOrderByClause);
 
         ctx.add(rollupField);
 
@@ -887,5 +951,28 @@ private class TestLREngine {
         System.assertEquals(2, masters.size());
         System.assertEquals(expected1, reloadedAcc1.get(rollupField.master.getName()));
         System.assertEquals(expected2, reloadedAcc2.get(rollupField.master.getName()));
-    }    
+    } 
+
+    static private void testRollup2(String detailOrderByClause, LREngine.RollupSummaryField rollupField, String expected1, String expected2) {
+
+        prepareData2();
+
+        LREngine.Context ctx = new LREngine.Context(
+            Account.SobjectType, 
+            Opportunity.SobjectType, 
+            Schema.SObjectType.Opportunity.fields.AccountId,
+            null, // detailWhereClause
+            detailOrderByClause);
+
+        ctx.add(rollupField);
+
+        SObject[] masters = LREngine.rollUp(ctx, detailRecords2);
+
+        Map<Id, SObject> mastersById = new Map<Id, SObject>(masters);
+        Account reloadedAcc3 = (Account)mastersById.get(acc3.Id);
+        Account reloadedAcc4 = (Account)mastersById.get(acc4.Id);
+        System.assertEquals(2, masters.size());
+        System.assertEquals(expected1, reloadedAcc3.get(rollupField.master.getName()));
+        System.assertEquals(expected2, reloadedAcc4.get(rollupField.master.getName()));
+    } 
 }

--- a/rolluptool/src/classes/TestLREngine.cls
+++ b/rolluptool/src/classes/TestLREngine.cls
@@ -786,6 +786,104 @@ private class TestLREngine {
                 'Won,Won,Lost');
     } 
 
+    /**
+     * Current default behavior of LREngine is to build the order by clause based on the following
+     *    1) LookupField then by
+     *    2) If detailOrderByClause is blank:
+     *           If context.fieldsToRoll.size() == 1 add context.fieldsToRoll[0].detail
+     *           If context.fieldsToRoll.size() > 1 then do not add any additional fields to orderby
+     *    3) If detailOrderByClause is not blank, add detailOrderByClause to orderby
+     *
+     * This results in all queries having an order by of at least lookupfield even if no orderby
+     * is specified on the context.  
+     *
+     * The context.fieldsToRoll.size() == 1 scenario is included strictly to maintain as much backwards compatibility
+     * as possible from previous release.  See https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/239#issuecomment-136122959
+     *
+     * Note that there is no reliable method for testing that when multiple fields are included in context
+     * and no order by is specified that the only field included in the orderby is the lookupfield.  To do
+     * this the SOQL would have to be exposed from LREngine.rollup and then parsed/evaluated and this seems
+     * kind of klunky.  Using debug statements, it's been verified that only lookupfield is included in
+     * order by in this scenario.
+     *
+     * Test that when no orderby is specified and only a single field is included in the context
+     * that the data is ordered by the fieldtoaggregate (StageName)
+     */
+    static testMethod void testSingleRollupSummaryFieldWithNoOrderByConcatVerifyDetailFieldIncludedInOrderBy() {
+        // create seed data 
+         prepareData2();
+        
+        LREngine.Context ctx = new LREngine.Context(Account.SobjectType, 
+                                                Opportunity.SobjectType, 
+                                                Schema.SObjectType.Opportunity.fields.AccountId);
+         
+        LREngine.RollupSummaryField rollupField = 
+            new LREngine.RollupSummaryField(
+                                            Schema.SObjectType.Account.fields.Description,
+                                            Schema.SObjectType.Opportunity.fields.StageName,
+                                            LREngine.RollupOperation.Concatenate, ','
+                                         ); 
+        ctx.add(rollupField);
+
+        SObject[] masters = LREngine.rollUp(ctx, detailRecords2);
+
+        Map<Id, SObject> mastersById = new Map<Id, SObject>(masters);
+        Account reloadedAcc3 = (Account)mastersById.get(acc3.Id);
+        Account reloadedAcc4 = (Account)mastersById.get(acc4.Id);
+        System.assertEquals(2, masters.size());
+        System.assertEquals('blue,red,yellow', reloadedAcc3.get(rollupField.master.getName()));
+        System.assertEquals('green,orange,purple', reloadedAcc4.get(rollupField.master.getName()));
+    }     
+
+    /**
+     * Current default behavior of LREngine is to build the order by clause based on the following
+     *    1) LookupField then by
+     *    2) If detailOrderByClause is blank:
+     *           If context.fieldsToRoll.size() == 1 add context.fieldsToRoll[0].detail
+     *           If context.fieldsToRoll.size() > 1 then do not add any additional fields to orderby
+     *    3) If detailOrderByClause is not blank, add detailOrderByClause to orderby
+     *
+     * This results in all queries having an order by of at least lookupfield even if no orderby
+     * is specified on the context.  
+     *
+     * The context.fieldsToRoll.size() == 1 scenario is included strictly to maintain as much backwards compatibility
+     * as possible from previous release.  See https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/239#issuecomment-136122959
+     *
+     * Note that there is no reliable method for testing that when multiple fields are included in context
+     * and no order by is specified that the only field included in the orderby is the lookupfield.  To do
+     * this the SOQL would have to be exposed from LREngine.rollup and then parsed/evaluated and this seems
+     * kind of klunky.  Using debug statements, it's been verified that only lookupfield is included in
+     * order by in this scenario.
+     *
+     * Test that when no orderby is specified and only a single field is included in the context
+     * that the data is ordered by the fieldtoaggregate (Name)
+     */
+    static testMethod void testSingleRollupSummaryFieldWithNoOrderByLastVerifyDetailFieldIncludedInOrderBy() {
+        // create seed data 
+         prepareData2();
+        
+        LREngine.Context ctx = new LREngine.Context(Account.SobjectType, 
+                                                Opportunity.SobjectType, 
+                                                Schema.SObjectType.Opportunity.fields.AccountId);
+         
+        LREngine.RollupSummaryField rollupField = 
+            new LREngine.RollupSummaryField(
+                                            Schema.SObjectType.Account.fields.Description,
+                                            Schema.SObjectType.Opportunity.fields.Name,
+                                            LREngine.RollupOperation.Last
+                                         ); 
+        ctx.add(rollupField);
+
+        SObject[] masters = LREngine.rollUp(ctx, detailRecords2);
+
+        Map<Id, SObject> mastersById = new Map<Id, SObject>(masters);
+        Account reloadedAcc3 = (Account)mastersById.get(acc3.Id);
+        Account reloadedAcc4 = (Account)mastersById.get(acc4.Id);
+        System.assertEquals(2, masters.size());
+        System.assertEquals('o3Acc3', reloadedAcc3.get(rollupField.master.getName()));
+        System.assertEquals('o3Acc4', reloadedAcc4.get(rollupField.master.getName()));
+    } 
+
     static testMethod void testRollupConcatenateOrderByMultipleAscendingNullsFirst() {
         testRollup2(
             'CloseDate, Type, Amount, Name',

--- a/rolluptool/src/classes/Utilities.cls
+++ b/rolluptool/src/classes/Utilities.cls
@@ -63,4 +63,127 @@ public class Utilities {
 		String namespace = namespace();
 		return String.isEmpty(namespace) ? '' : (namespace + '__');
 	}
+
+	/**
+	 * Parse a string that follows the SOQL Order By standard
+	 * 
+	 * @param orderByClause - order by clause (not including ORDER BY keywords) following standard at https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_orderby.htm
+	 *
+	 * @return list containing one LREngine.Ordering element for each field in the order by clause
+	 *
+	 * @throw  OrderByInvalidException when order by is not in proper format
+	 **/
+	public static List<Utilities.Ordering> parseOrderByClause(String orderByClause)
+	{
+		if (String.isBlank(orderByClause)) {
+			return null;
+		}
+
+		List<Utilities.Ordering> orderByFields = new List<Utilities.Ordering>();
+		List<String> orderByClauseFields = orderByClause.split(',');
+		for(String field :orderByClauseFields) {
+			orderByFields.add(parseOrderByField(field));
+		}
+
+		return orderByFields;
+	}
+
+	// Regular expression for Order By Clause
+	// Case-Insensitive pattern
+	// Group 1 - Field Name (required)
+	// Group 2 - ASC/DESC (optional)
+	// Group 3 - NULLS FIRST (optional)
+	// Group 4 - NULLS (required if Group 3 != null)
+	// Group 5 - FIRST (required if Group 3 != null)
+	private static Pattern orderByPattern = Pattern.compile('^(?i)[\\s]*([\\w]+)[\\s]*(ASC|DESC)?[\\s]*((NULLS)[\\s]*(FIRST|LAST))?[\\s]*$');
+	private static Utilities.Ordering parseOrderByField(String orderByField)
+	{
+		Matcher matcher = orderByPattern.matcher(orderByField);
+		if (!matcher.matches() || matcher.groupCount() != 5) {
+			throw new Utilities.OrderByInvalidException('Invalid order by clause.');
+		}
+
+		// regex enforces that fieldname cannot be blank
+		String fieldName = matcher.group(1);
+
+		// regex enforces that ordering be null, ASC or DESC
+		// == operator is case-insensitive
+		String ordering = matcher.group(2);
+		Utilities.SortOrder sortOrder = (ordering == null) ? null : (ordering == 'DESC' ? Utilities.SortOrder.DESCENDING : Utilities.SortOrder.ASCENDING);
+
+		// regex enforces that firstLast be null, FIRST or LAST
+		// == operator is case-insensitive		
+		String firstLast = matcher.group(5);		
+		Boolean nullsLast = (firstLast == null) ? null : (firstLast == 'LAST');
+
+		return new Utilities.Ordering(fieldName, sortOrder, nullsLast);
+	}
+
+    /**
+        Sort Order
+    */
+    public enum SortOrder {ASCENDING, DESCENDING}
+
+    /**
+        Represents a single portion of the Order By clause for SOQL statement
+    */
+    public class Ordering{
+        private SortOrder direction;
+        private Boolean nullsLast;
+        private String field;
+        private Boolean directionSpecified; // if direction was specified during construction
+        private Boolean nullsLastSpecified; // if nullsLast was specified during construction
+
+        /**
+         * Construct a new ordering instance
+        **/
+        public Ordering(String field) {
+            this(field, null);
+        }        
+        public Ordering(String field, SortOrder direction) {
+            this(field, direction, null);
+        }
+        public Ordering(String field, SortOrder direction, Boolean nullsLast) {
+            setField(field);
+            this.directionSpecified = direction != null;
+            this.nullsLastSpecified = nullsLast != null;
+            this.direction = this.directionSpecified ? direction : SortOrder.ASCENDING; //SOQL docs ASC is default behavior
+            this.nullsLast = this.nullsLastSpecified ? nullsLast : false; //SOQL docs state NULLS FIRST is default behavior
+        }
+        public String getField() {
+            return field;
+        }
+        public void setField(String field) {
+        	if (String.isBlank(field)) {
+				throw new Utilities.BadOrderingStateException('field cannot be blank.');
+        	}
+        	this.field = field;
+        }
+        public SortOrder getDirection() {
+            return direction;
+        }
+        public Boolean getNullsLast() {
+            return nullsLast;
+        }
+        public override String toString() {
+            return field + ' ' + (direction == Utilities.SortOrder.ASCENDING ? 'ASC' : 'DESC') + ' ' + (nullsLast ? 'NULLS LAST' : 'NULLS FIRST');
+        }
+        public String toAsSpecifiedString() {
+            // emit order by using describe info with the direction and nullsLast
+            // that was provided during construction.  This allows to regurgitate
+            // the proper SOQL order by using exactly what was passed in
+            return field + (directionSpecified ? (direction == Utilities.SortOrder.ASCENDING ? ' ASC' : ' DESC') : '') + (nullsLastSpecified ? (nullsLast ? ' NULLS LAST' : ' NULLS FIRST') : '');
+        }
+    }	
+
+
+    /**
+        Exception thrown if Order by clause is invalid
+    */    
+	public class OrderByInvalidException extends Exception {}
+
+    /**
+        Exception thrown if Ordering is in bad state
+    */
+    public class BadOrderingStateException extends Exception {}
 }

--- a/rolluptool/src/layouts/LookupChild__c-Lookup Child Layout.layout
+++ b/rolluptool/src/layouts/LookupChild__c-Lookup Child Layout.layout
@@ -26,6 +26,14 @@
                 <behavior>Edit</behavior>
                 <field>LookupParent2__c</field>
             </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Description__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Description2__c</field>
+            </layoutItems>
         </layoutColumns>
         <layoutColumns>
             <layoutItems>

--- a/rolluptool/src/layouts/LookupParent__c-Lookup Parent Layout.layout
+++ b/rolluptool/src/layouts/LookupParent__c-Lookup Parent Layout.layout
@@ -17,7 +17,19 @@
             </layoutItems>
             <layoutItems>
                 <behavior>Edit</behavior>
+                <field>Total2__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
                 <field>Colours__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Descriptions__c</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>Descriptions2__c</field>
             </layoutItems>
         </layoutColumns>
         <layoutColumns>

--- a/rolluptool/src/objects/LookupChild__c.object
+++ b/rolluptool/src/objects/LookupChild__c.object
@@ -94,6 +94,26 @@
         <type>Picklist</type>
     </fields>
     <fields>
+        <fullName>Description2__c</fullName>
+        <externalId>false</externalId>
+        <label>Description 2</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Description__c</fullName>
+        <externalId>false</externalId>
+        <label>Description</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>LookupParent2__c</fullName>
         <deleteConstraint>SetNull</deleteConstraint>
         <deprecated>false</deprecated>        

--- a/rolluptool/src/objects/LookupParent__c.object
+++ b/rolluptool/src/objects/LookupParent__c.object
@@ -83,6 +83,26 @@
         <visibleLines>4</visibleLines>
     </fields>
     <fields>
+        <fullName>Descriptions2__c</fullName>
+        <externalId>false</externalId>
+        <label>Descriptions 2</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
+        <fullName>Descriptions__c</fullName>
+        <externalId>false</externalId>
+        <label>Descriptions</label>
+        <length>255</length>
+        <required>false</required>
+        <trackTrending>false</trackTrending>
+        <type>Text</type>
+        <unique>false</unique>
+    </fields>
+    <fields>
         <fullName>Total2__c</fullName>
         <externalId>false</externalId>
         <label>Total 2</label>

--- a/rolluptool/src/objects/LookupRollupSummary__c.object
+++ b/rolluptool/src/objects/LookupRollupSummary__c.object
@@ -237,10 +237,14 @@
     <fields>
         <fullName>FieldToOrderBy__c</fullName>
         <deprecated>false</deprecated>
+        <description>Examples:
+1) Amount__c
+2) Amount__c, Color__c ASC
+3) Amount__c NULLS LAST, Color__c DESC NULLS LAST</description>
         <externalId>false</externalId>
-        <inlineHelpText>Only applicable when using the Concatenate, Concatenate Distinct, Last and First aggregate operations. Defaults to the field given in Field to Aggregate.</inlineHelpText>
+        <inlineHelpText>Only applicable when using the Concatenate, Concatenate Distinct, Last and First aggregate operations. Supports multiple fields (comma separated) with optional ASC/DESC and/or NULLS FIRST/LAST.</inlineHelpText>
         <label>Field to Order By</label>
-        <length>80</length>
+        <length>255</length>
         <required>false</required>
         <trackTrending>false</trackTrending>
         <type>Text</type>


### PR DESCRIPTION
This PR is an alternative to PR #238 (#238 or this PR should be merged, not both) and incorporates Issue #239 moving the order by to the context, eliminating any default orderby applied when none is specified (except for RelationshipField__c) and updating the helptext of FieldToOrderBy__c .  It also includes #216 and #240.

Since this was all fresh in my mind, I decided to implement #239 in case it's decided to use that approach instead of keeping the order by on the RollupSummaryField.  Based on working through #216 and the other issues identified that were addressed around orderby, I believe the approach in this PR should be chosen as it offers the benefits mentioned in #239.  The downside to this PR as opposed to #238 is that it does change signatures of RollupSummaryField and Context constructors. However, since the orderby did not make it to LRE project, the surface area of the impact is minimized to DLRS internally and anyone using DLRS source only.  The change to use the context will result in different rolled up results when no order by is specified compared to the ThenBy approach when RollupSummaryField contains the orderby.  However, in both cases it is a non-deterministic result so the net effect is essentially the same.  Moving to context seems to be a more natural way to manage the order by based on DLRS usage and avoids a lot of unnecessary processing.

**Note**
* If the decision is made to **NOT** implement #239, then PR #238 should be merged and PR #241 cancelled.  
* If the decision is made to implement #239, then PR #241 should be merged and PR #238 cancelled.