### PR TITLE
Allow First/Last Summaries to work on Id and Reference Fields

### DIFF
--- a/rolluptool/src/classes/LREngine.cls
+++ b/rolluptool/src/classes/LREngine.cls
@@ -372,6 +372,8 @@ public class LREngine {
         public boolean isMasterTypeCurrency;
         public boolean isMasterTypeText;
         public boolean isDetailTypeText;
+        public boolean isMasterTypeId;
+        public boolean isDetailTypeId;
 
         public RollupSummaryField(Schema.Describefieldresult m, 
                                          Schema.Describefieldresult d, RollupOperation op) {
@@ -396,6 +398,8 @@ public class LREngine {
             this.isMasterTypeCurrency = isCurrency(master.getType());
             this.isMasterTypeText = isText(master.getType());
             this.isDetailTypeText = isText(detail.getType());
+			this.isMasterTypeId = isIdOrReference(master.getType());
+            this.isDetailTypeId = isIdOrReference(detail.getType());
             // validate if field is good to work on later 
             validate();
         }   
@@ -414,8 +418,9 @@ public class LREngine {
             if (operation == RollupOperation.First ||
                 operation == RollupOperation.Last) {
                 if ( (this.master.getType() != this.detail.getType()) &&
-                     (!isDetailTypeText && !isMasterTypeText) ) {
-                    throw new BadRollUpSummaryStateException('Master and detail fields must be the same field type (or text based) for First or Last operations');
+                     ((!isDetailTypeText && !isDetailTypeId) || 
+                     (!isMasterTypeText && !isMasterTypeId))) {
+                    throw new BadRollUpSummaryStateException('Master and detail fields must be the same field type (or text/Id based) for First or Last operations');
                 }
             }
 
@@ -439,6 +444,11 @@ public class LREngine {
                 dt == Schema.Displaytype.String ||
                 dt == Schema.Displaytype.Picklist ||
                 dt == Schema.Displaytype.MultiPicklist;
+        }
+        
+        boolean isIdOrReference (Schema.Displaytype dt) {
+            return dt == Schema.DisplayType.ID ||
+                   dt == Schema.DisplayType.REFERENCE;
         }
 
         boolean isNumber (Schema.Displaytype dt) {

--- a/rolluptool/src/classes/TestLREngine.cls
+++ b/rolluptool/src/classes/TestLREngine.cls
@@ -711,7 +711,7 @@ private class TestLREngine {
                 LREngine.RollupOperation.Last));                 
             System.assert(false, 'Expecting an exception');            
         } catch (Exception e) {
-            System.assertEquals('Master and detail fields must be the same field type (or text based) for First or Last operations', e.getMessage());
+            System.assertEquals('Master and detail fields must be the same field type (or text/Id based) for First or Last operations', e.getMessage());
         }
         try {
             LREngine.Context ctx = 
@@ -724,7 +724,7 @@ private class TestLREngine {
                 LREngine.RollupOperation.First));                 
             System.assert(false, 'Expecting an exception');            
         } catch (Exception e) {
-            System.assertEquals('Master and detail fields must be the same field type (or text based) for First or Last operations', e.getMessage());
+            System.assertEquals('Master and detail fields must be the same field type (or text/Id based) for First or Last operations', e.getMessage());
         }
         // Master and detail field type match
         try {


### PR DESCRIPTION
This pull request changes the data type requirements for First/Last Summaries to include Id and Reference as valid types. 

This change allows a user to have a summary result field be of type REFERENCE, and aggregate the Id of the first/last child into it, setting that lookup field.

An example:
Account has a lookup to "Largest Won Opportunity". The user would create a DLRS summary that aggregates Id into Largest_Won_Opportunity__c of Type "First" ordered by "Amount DESC" with a filter IsWon=True. 

This would set the largest won opportunity lookup on closure of a large opportunity. Then, the user could create formula fields or use other platform features to quickly get to details about that account's largest won opportunity.

A non-profit use case is setting the current program enrollment for a given client.