### PR TITLE
issue #258 and issue #278 - Space/Tab tokens and multiple BR/token su…

### DIFF
--- a/rolluptool/src/classes/LREngine.cls
+++ b/rolluptool/src/classes/LREngine.cls
@@ -307,6 +307,12 @@ public class LREngine {
         return masterRecordsMap.values();   
     }
 
+    private final static Map<Pattern, String> delimiterTokens = new Map<Pattern, String> {
+        Pattern.compile('BR\\(\\)') => '\n'
+        , Pattern.compile('SP\\(\\)') => ' '
+        , Pattern.compile('TB\\(\\)') => '\t'
+    };
+
     /**
      * Concatenates strings (removes duplicates)
      **/
@@ -319,8 +325,12 @@ public class LREngine {
 
         public Concatenator(Boolean distinct, String delimiter) {
             this.distinct = distinct;
-            if(delimiter!=null)
-                this.delimiter = delimiter.equals('BR()') ? '\n' : delimiter;
+            if(delimiter!=null) {
+                for (Pattern p : delimiterTokens.keySet()) {
+                    delimiter = p.matcher(delimiter).replaceAll((String)delimiterTokens.get(p));
+                }
+                this.delimiter = delimiter;
+            }
             setOfStrings = new Set<String>();
             listOfString = new List<String>();
         }

--- a/rolluptool/src/classes/TestLREngine.cls
+++ b/rolluptool/src/classes/TestLREngine.cls
@@ -773,7 +773,117 @@ private class TestLREngine {
                     LREngine.RollupOperation.Concatenate, 'BR()'),
                 'test\ntest\ntest',
                 'Lost\nWon\nWon');
-    } 
+    }
+
+    static testMethod void testRollupConcatenateMultipleBR() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, 'BR()BR()BR()'),
+                'test\n\n\ntest\n\n\ntest',
+                'Lost\n\n\nWon\n\n\nWon');
+    }
+
+    static testMethod void testRollupConcatenateCommaBR() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, ',BR()'),
+                'test,\ntest,\ntest',
+                'Lost,\nWon,\nWon');
+    }    
+
+    static testMethod void testRollupConcatenateSP() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, 'SP()'),
+                'test test test',
+                'Lost Won Won');
+    }
+
+    static testMethod void testRollupConcatenateMultipleSP() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, 'SP()SP()SP()'),
+                'test   test   test',
+                'Lost   Won   Won');
+    }
+
+    static testMethod void testRollupConcatenateCommaSP() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, ',SP()'),
+                'test, test, test',
+                'Lost, Won, Won');
+    }    
+
+    static testMethod void testRollupConcatenateTB() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, 'TB()'),
+                'test\ttest\ttest',
+                'Lost\tWon\tWon');
+    }
+
+    static testMethod void testRollupConcatenateMultipleTB() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, 'TB()TB()TB()'),
+                'test\t\t\ttest\t\t\ttest',
+                'Lost\t\t\tWon\t\t\tWon');
+    }   
+
+    static testMethod void testRollupConcatenateCommaTB() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, ',TB()'),
+                'test,\ttest,\ttest',
+                'Lost,\tWon,\tWon');
+    }      
+
+    static testMethod void testRollupConcatenateAllTokens() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, 'TB()BR()SP()'),
+                'test\t\n test\t\n test',
+                'Lost\t\n Won\t\n Won');
+    }   
+
+    static testMethod void testRollupConcatenateCommaAllTokens() {
+        testRollup(
+            Schema.SObjectType.Opportunity.fields.StageName.getName(),
+            new LREngine.RollupSummaryField(
+                    Schema.SObjectType.Account.fields.Description,
+                    Schema.SObjectType.Opportunity.fields.StageName,
+                    LREngine.RollupOperation.Concatenate, ',TB()BR()SP()'),
+                'test,\t\n test,\t\n test',
+                'Lost,\t\n Won,\t\n Won');
+    }       
 
     static testMethod void testRollupConcatenateOrderBy() {
         testRollup(


### PR DESCRIPTION
…pport

Add support for Space (SP()) and Tab (TB()) tokens; Add support for
multiple tokens (including existing BR()) in delimiter

Note - This provides for backwards compat with existing "BR()" functionality.  However, if an existing LookupRollupSummary contains a delimiter with the text "SP()" or "TB()" or if "BR()" exists within a delimiter that is not exactly "BR()" only, this will cause a regression.  Providing a way to "escape" these tokens would require an endless exercise so due to the fact that it is extremely unlikely that these tokens already exist within a delimiter value I've decided not to provide a way to specify SP(), TB() or BR() in a delimiter that would not be translated to "space", "tab" or "carriage return."  If you feel that this is something that is needed, I can update this PR to provide a backslash ("\") style of escaping.  Note that even with a single backslash style escaping, that too would need an escape pattern, which would need an escape pattern, etc.  ;)