### PR TITLE
Issue 359 resolved - Manual Calculate without marking Active

### DIFF
--- a/rolluptool/src/classes/RollupService.cls
+++ b/rolluptool/src/classes/RollupService.cls
@@ -98,7 +98,7 @@ global with sharing class RollupService
 		}
 
 		// Already active?
-		if(lookup.Active==null || lookup.Active==false)
+		if((lookup.Active==null || lookup.Active==false) && lookup.CalculationMode=='Realtime' )
 			throw new RollupServiceException('The rollup must be Active before you can run a Calculate job.');
 
 		// Start the job and record the Job Id

--- a/rolluptool/src/classes/RollupServiceTest3.cls
+++ b/rolluptool/src/classes/RollupServiceTest3.cls
@@ -271,7 +271,7 @@ private with sharing class RollupServiceTest3
 		rollupSummary.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
 		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.Active__c = false;
-		rollupSummary.CalculationMode__c = 'Scheduled';
+		rollupSummary.CalculationMode__c = 'Realtime';
 		insert rollupSummary;
 
 		// Run rollup calculate job


### PR DESCRIPTION
Minor changes to prevent needing to check Active in order to do a manual
calculation when the Calculation mode is not Realtime.

