### PR TITLE
Fixes issue #558 by avoiding running query that won't have any masterRecordIds to filter by

### DIFF
--- a/rolluptool/src/classes/LREngine.cls
+++ b/rolluptool/src/classes/LREngine.cls
@@ -656,6 +656,9 @@ public class LREngine {
      **/
     public abstract class QueryExecutor {
         public virtual List<SObject> query(String query, Set<Id> masterIds) {
+            if ( masterIds == null || masterIds.isEmpty() ) {
+                return new List<SObject>();
+            }
             return Database.query(query);
         }
     }


### PR DESCRIPTION
Objects like `ContentDocumentLink` have implementation restrictions that prohibit empty query parameters on its parent fields `LinkedEntityId` or `ContentDocumentId`.

While troubleshooting this issue, I narrowed down the problem to `RollupService` line 163 where master record ids whose sobject type does not match that of the rollup's master type are filtered out. This likely doesn't happen often, but with `ContentDocumentLink` this happens every time a new File or Enhanced Note is created via the web UI when on a record detail page because two CDLs are created: one to share the new File/Note with the create user and one to share the new File/Note with the parent record (e.g. account or contact).

The error reported in issue #558 occurs when rollup calculation mode is **realtime** and the framework is trying to process the CDL whose `LinkedEntityId` field does not match the sobject type of the rollup's master type. Since the `LinkedEntityId` field value is never added to the `ctxMasterIds` then the code eventually executes `QueryExecutor.query(String query, Set<Id> masterIds)` passing in an empty set of record ids. Whereas most objects being queried don't fail when filtering on empty set of ids `WHERE field IN ()` the `ContentDocumentLink` object will throw error and fail. Therefore, this pull request simply checks if the master record ids collection is null or empty and if yes then returns empty list. I'm not aware of any scenario where if the query were to be run would ever return records anyways.

Thanks!