### PR TITLE
Fix #794

### DIFF
--- a/force-app/main/classes/RollupService.cls
+++ b/force-app/main/classes/RollupService.cls
@@ -2,22 +2,22 @@
  * Copyright (c), Andrew Fawcett
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  *   are permitted provided that the following conditions are met:
  *
- * - Redistributions of source code must retain the above copyright notice, 
+ * - Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice, 
- *      this list of conditions and the following disclaimer in the documentation 
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
  *      and/or other materials provided with the distribution.
- * - Neither the name of the Andrew Fawcett, nor the names of its contributors 
- *      may be used to endorse or promote products derived from this software without 
+ * - Neither the name of the Andrew Fawcett, nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
  *      specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
- *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
- *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
- *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
  *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
@@ -32,7 +32,7 @@
  *   TODO: As this class has developed to support schedule and develoepr API entry points some further refactoring for reuse can be done
  **/
 global with sharing class RollupService
-{	
+{
 	global static Exception LastMetadataAPIConnectionException {get; private set;}
 
 	global static Boolean checkMetadataAPIConnection()
@@ -41,11 +41,11 @@ global with sharing class RollupService
 			MetadataService.MetadataPort service = new MetadataService.MetadataPort();
 			service.SessionHeader = new MetadataService.SessionHeader_element();
 			service.SessionHeader.sessionId = UserInfo.getSessionId();
-			List<MetadataService.ListMetadataQuery> queries = new List<MetadataService.ListMetadataQuery>();		
+			List<MetadataService.ListMetadataQuery> queries = new List<MetadataService.ListMetadataQuery>();
 			MetadataService.ListMetadataQuery remoteSites = new MetadataService.ListMetadataQuery();
 			remoteSites.type_x = 'RemoteSiteSetting';
-			queries.add(remoteSites);					
-			service.listMetadata(queries, 28);			
+			queries.add(remoteSites);
+			service.listMetadata(queries, 28);
 		} catch (Exception e) {
 			LastMetadataAPIConnectionException = e;
 			return false;
@@ -53,9 +53,9 @@ global with sharing class RollupService
 		LastMetadataAPIConnectionException = null;
 		return true;
 	}
-	
+
 	/**
-	 * Starts the Job to recalculate the given rollup 
+	 * Starts the Job to recalculate the given rollup
 	 **/
 	global static Id runJobToCalculate(Id lookupId)
 	{
@@ -71,7 +71,7 @@ global with sharing class RollupService
 	}
 
 	/**
-	 * Starts the Job to recalculate the given rollup 
+	 * Starts the Job to recalculate the given rollup
 	 **/
 	global static Id runJobToCalculate(String lookupId)
 	{
@@ -84,35 +84,35 @@ global with sharing class RollupService
 	global static Id runJobToCalculate(String lookupId, String masterWhereClause)
 	{
 		System.SavePoint sp = Database.setSavepoint();
-		
+
 		try {
-			
+
 			// Is another calculate job running for this lookup?
 			List<RollupSummary> lookups = new RollupSummariesSelector().selectById(new Set<String> { (String) lookupId });
 			if(lookups.size()==0)
 				throw RollupServiceException.rollupNotFound(lookupId);
 			RollupSummary lookup = lookups[0];
-	
+
 			// Already running?
 			checkJobAlreadyRunning(lookupId, lookup.Name);
-	
+
 			// Already active?
 			if((lookup.Active==null || lookup.Active==false) && lookup.CalculationMode=='Realtime' )
 				throw new RollupServiceException('The rollup must be Active before you can run a Calculate job.');
-	
+
 			// Start the job and record the Job Id
 			Integer scopeSize = (Integer) DeclarativeLookupRollupSummaries__c.getInstance().CalculateJobScopeSize__c;
 			Id jobId = Database.executeBatch(new RollupCalculateJob(lookupId, masterWhereClause), scopeSize == null ? 100 : scopeSize);
-	
+
 			// Update CalculateJobId__c for Custom Object based rollups?
 			if(lookup.Record instanceof LookupRollupSummary__c) {
 				LookupRollupSummary__c rollupSummary = (LookupRollupSummary__c) lookup.Record;
 				rollupSummary.CalculateJobId__c = jobId;
 				update lookup.Record;
 			}
-	
+
 			return jobId;
-						
+
 		} catch (Exception e) {
 			// Fix for https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/511, avoid leaking control record
 			Database.rollback(sp);
@@ -121,18 +121,18 @@ global with sharing class RollupService
 	}
 
 	/**
-	 * Starts the Job to process the scheduled items for rollup 
+	 * Starts the Job to process the scheduled items for rollup
 	 **/
 	global static Id runJobToProcessScheduledItems()
 	{
 		// Check if the Job is already running before starting a new one
 		if(new AsyncApexJobsSelector().jobsExecuting(new Set<String> { 'RollupJob' }))
 			throw RollupServiceException.jobsExecuting('RollupJob');
-			
-		// Start the job to processed the scheduled items	
+
+		// Start the job to processed the scheduled items
 		Integer scopeSize = (Integer) DeclarativeLookupRollupSummaries__c.getInstance().ScheduledJobScopeSize__c;
 		return Database.executeBatch(new RollupJob(), scopeSize == null ? 100 : scopeSize);
-	}	
+	}
 
 	/**
 	 * Describes a specific rollup to process
@@ -164,18 +164,18 @@ global with sharing class RollupService
 			return;
 
 		// Process each context (parent child relationship) and its associated rollups
-		Map<Id, SObject> masterRecords = new Map<Id, SObject>();		
+		Map<Id, SObject> masterRecords = new Map<Id, SObject>();
 		for(LREngine.Context ctx : createLREngineContexts(lookups))
 		{
-			// Produce a set of master Id's applicable to this context (parent only)			
+			// Produce a set of master Id's applicable to this context (parent only)
 			Set<Id> ctxMasterIds = new Set<Id>();
 			for(Id masterId : masterIds)
 				if(masterId.getSObjectType() == ctx.master)
 					ctxMasterIds.add(masterId);
 			// Execute the rollup and process the resulting updated master records
-			for(SObject masterRecord : LREngine.rollup(ctx, ctxMasterIds)) 
+			for(SObject masterRecord : LREngine.rollup(ctx, ctxMasterIds))
 			{
-				// Skip master records without Id's (LREngine can return these where there was 
+				// Skip master records without Id's (LREngine can return these where there was
 				//	no related master records to children, for examlpe where a relationship is optional)
 				if(masterRecord.Id==null)
 					break;
@@ -185,9 +185,9 @@ global with sharing class RollupService
 					masterRecords.put(masterRecord.Id, masterRecord);
 				else
 					for(LREngine.RollupSummaryField fieldToRoll : ctx.fieldsToRoll)
-						existingRecord.put(fieldToRoll.master.getSObjectField(), 
+						existingRecord.put(fieldToRoll.master.getSObjectField(),
 							masterRecord.get(fieldToRoll.master.getSObjectField()));
-			}			
+			}
 		}
 
 		// Update the master records
@@ -195,7 +195,7 @@ global with sharing class RollupService
 	}
 
 	/**
-	 * Developer API for the tool, only executes Rollup Summmaries with Calculation Mode set to Developer 
+	 * Developer API for the tool, only executes Rollup Summmaries with Calculation Mode set to Developer
 	 *
 	 * Automatically resolves child records to process via LREngine and lookups described in RollupSummary
 	 *    also determines if based on the old records if the rollup processing needs to occur
@@ -207,36 +207,36 @@ global with sharing class RollupService
 	 * @usage rollup(Trigger.oldMap, Trigger.newMap, Account.SObjectType)
 	 *
 	 * @remark All SObjects (existing and new) must be of the same SObjectType
-	 * @remark Supports mixture of old/new records.  For example, you can include a record in existing 
+	 * @remark Supports mixture of old/new records.  For example, you can include a record in existing
 	 *         that was deleted and a record in new that was inserted.
-	 **/ 
+	 **/
 	global static void rollup(Map<Id, SObject> existingRecords, Map<Id, SObject> newRecords, Schema.SObjectType sObjectType)
 	{
 		handleRollups(existingRecords, newRecords, sObjectType, new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Developer });
 	}
 
 	/**
-	 * Developer API for the tool, only executes Rollup Summmaries with Calculation Mode set to Developer 
+	 * Developer API for the tool, only executes Rollup Summmaries with Calculation Mode set to Developer
 	 *
 	 * @param childRecords Child records being modified
 	 * @returns Array of master records containing the updated rollups, calling code must perform update DML operation
-	 **/ 
+	 **/
 	global static List<SObject> rollup(List<SObject> childRecords)
 	{
 		// Anything to process?
 		if(childRecords==null || childRecords.size()==0)
 			return new List<SObject>();
-			
+
 		// Describe Developer rollups for these child records
 		SObjectType childObjectType = childRecords[0].Id.getSObjectType();
-		Schema.DescribeSObjectResult childRecordDescribe = childObjectType.getDescribe();		
+		Schema.DescribeSObjectResult childRecordDescribe = childObjectType.getDescribe();
 		List<RollupSummary> lookups =
 			new RollupSummariesSelector().selectActiveByChildObject(
-				new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Developer }, 
+				new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Developer },
 				new Set<String> { childRecordDescribe.getName() });
 		if(lookups.size()==0)
 			return new List<SObject>(); // Nothing to see here! :)
-			
+
 		// Rollup child records and update master records
 		Set<Id> masterRecordIds = new Set<Id>();
 		for(SObject childRecord : childRecords)
@@ -245,18 +245,18 @@ global with sharing class RollupService
 					masterRecordIds.add((Id)childRecord.get(lookup.RelationShipField));
 
 		// Process each context (parent child relationship) and its associated rollups
-		Map<Id, SObject> masterRecords = new Map<Id, SObject>();		
+		Map<Id, SObject> masterRecords = new Map<Id, SObject>();
 		for(LREngine.Context ctx : createLREngineContexts(lookups))
 		{
-			// Produce a set of master Id's applicable to this context (parent only)			
+			// Produce a set of master Id's applicable to this context (parent only)
 			Set<Id> ctxMasterIds = new Set<Id>();
 			for(Id masterId : masterRecordIds)
 				if(masterId.getSObjectType() == ctx.master)
 					ctxMasterIds.add(masterId);
 			// Execute the rollup and process the resulting updated master records
-			for(SObject masterRecord : LREngine.rollup(ctx, ctxMasterIds)) 
+			for(SObject masterRecord : LREngine.rollup(ctx, ctxMasterIds))
 			{
-				// Skip master records without Id's (LREngine can return these where there was 
+				// Skip master records without Id's (LREngine can return these where there was
 				//	no related master records to children, for examlpe where a relationship is optional)
 				if(masterRecord.Id==null)
 					break;
@@ -266,9 +266,9 @@ global with sharing class RollupService
 					masterRecords.put(masterRecord.Id, masterRecord);
 				else
 					for(LREngine.RollupSummaryField fieldToRoll : ctx.fieldsToRoll)
-						existingRecord.put(fieldToRoll.master.getSObjectField(), 
+						existingRecord.put(fieldToRoll.master.getSObjectField(),
 							masterRecord.get(fieldToRoll.master.getSObjectField()));
-			}			
+			}
 		}
 		return masterRecords.values();
 	}
@@ -276,7 +276,7 @@ global with sharing class RollupService
 	/**
 	 * Apex Test handler (call from Apex Test only)
 	 **/
-	global static void testHandler(SObject dummyChildRecord) 
+	global static void testHandler(SObject dummyChildRecord)
 	{
 		try {
 			insert dummyChildRecord;
@@ -288,7 +288,7 @@ global with sharing class RollupService
 			throw e;
 		}
 	}
-	
+
 	/**
 	 * Used in a test context to determine if errors from the dummy child insert should fail the test
 	 **/
@@ -305,8 +305,8 @@ global with sharing class RollupService
 
         // Currently no processing in the before phase
         if(Trigger.isBefore)
-            return;     
-            
+            return;
+
         // Anything to rollup?
         handleRollups(Trigger.oldMap, Trigger.newMap, childObjectType, new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Realtime, RollupSummaries.CalculationMode.Scheduled });
     }
@@ -321,11 +321,11 @@ global with sharing class RollupService
 
 		// Currently no processing in the before phase
 		if(Trigger.isBefore)
-			return;		
-			
+			return;
+
 		// Anything to rollup?
 		List<SObject> childRecords = Trigger.isDelete ? Trigger.old : Trigger.new;
-		SObjectType childObjectType = childRecords[0].Id.getSObjectType();		
+		SObjectType childObjectType = childRecords[0].Id.getSObjectType();
 		handleRollups(Trigger.oldMap, Trigger.newMap, childObjectType, new List<RollupSummaries.CalculationMode> { RollupSummaries.CalculationMode.Realtime, RollupSummaries.CalculationMode.Scheduled });
 	}
 
@@ -352,17 +352,17 @@ global with sharing class RollupService
 
 	/**
 	 * Clears the Calcualte Job Id's on the given lookups preventng concurrent Calculate jobs
-	 **/ 	
+	 **/
 	public static void clearCalculateJobId(Set<String> lookupIds)
 	{
-	    // LookupRollupSummaryId__c are 18 char Ids ensure the ones we filter on are as well 
+	    // LookupRollupSummaryId__c are 18 char Ids ensure the ones we filter on are as well
 	    Set<String> char18Ids = new Set<String>();
 	    for(String lookupId : lookupIds) {
 	        char18Ids.add((String) ((Id)lookupId));
 	    }
 		delete [select Id from LookupRollupCalculateJob__c where LookupRollupSummaryId__c in :char18Ids];
 	}
-	
+
 	/**
 	 * Method called from the RollupJob to handle summary schedule items that have been generated
 	 **/
@@ -370,15 +370,15 @@ global with sharing class RollupService
 	{
 		// Load related Lookup summaries for the scheduled items
 		Set<String> lookupIds = new Set<String>();
-		for(LookupRollupSummaryScheduleItems__c scheduleItem : rollupSummaryScheduleItems) {			
+		for(LookupRollupSummaryScheduleItems__c scheduleItem : rollupSummaryScheduleItems) {
 			lookupIds.add(scheduleItem.LookupRollupSummary2__c);
 		}
-		Map<String, RollupSummary> lookups = 
+		Map<String, RollupSummary> lookups =
 			RollupSummary.toMap(new RollupSummariesSelector().selectById(lookupIds));
-			
+
 		// Group the parent Id's by parent type
 		Map<String, Schema.SObjectType> gd = Schema.getGlobalDescribe();
-		Map<String, Set<Id>> parentIdsByParentType = new Map<String, Set<Id>>();  
+		Map<String, Set<Id>> parentIdsByParentType = new Map<String, Set<Id>>();
 		for(LookupRollupSummaryScheduleItems__c scheduleItem : rollupSummaryScheduleItems)
 		{
 			Id parentId = scheduleItem.ParentId__c;
@@ -391,12 +391,12 @@ global with sharing class RollupService
 				parentIdsByParentType.put(lookup.ParentObject, (parentIds = new Set<Id>()));
 			parentIds.add(parentId);
 		}
-			
+
 		// Group lookups by parent and relationship into LREngine ctx's
 		List<LREngine.Context> engineCtxByParentRelationship = createLREngineContexts(lookups.values());
 
 		// Process each context (parent child relationship) and its associated rollups
-		Map<Id, SObject> masterRecords = new Map<Id, SObject>();		
+		Map<Id, SObject> masterRecords = new Map<Id, SObject>();
 		for(LREngine.Context ctx : engineCtxByParentRelationship)
 		{
 			Set<Id> masterIds = parentIdsByParentType.get(ctx.master.getDescribe().getName());
@@ -404,7 +404,7 @@ global with sharing class RollupService
 			if(masterIds!=null && masterIds.size()>0) {
 				for(SObject masterRecord : LREngine.rollup(ctx, masterIds))
 				{
-					// Skip master records without Id's (LREngine can return these where there was 
+					// Skip master records without Id's (LREngine can return these where there was
 					//	no related master records to children, for examlpe where a relationship is optional)
 					if(masterRecord.Id==null)
 						continue;
@@ -414,14 +414,14 @@ global with sharing class RollupService
 						masterRecords.put(masterRecord.Id, masterRecord);
 					else
 						for(LREngine.RollupSummaryField fieldToRoll : ctx.fieldsToRoll)
-							existingRecord.put(fieldToRoll.master.getSObjectField(), 
+							existingRecord.put(fieldToRoll.master.getSObjectField(),
 								masterRecord.get(fieldToRoll.master.getSObjectField()));
 				}
 			}
 		}
 
 		// Map rollup summary schedule items by parent id, in order to remove only those whos parent/master record actually gets updated below
-		Map<Id, List<LookupRollupSummaryScheduleItems__c>> rollupSummaryScheduleItemsByParentId = 
+		Map<Id, List<LookupRollupSummaryScheduleItems__c>> rollupSummaryScheduleItemsByParentId =
 			new Map<Id, List<LookupRollupSummaryScheduleItems__c>>();
 		for(LookupRollupSummaryScheduleItems__c rollupSummaryScheduleItem : rollupSummaryScheduleItems)
 		{
@@ -433,12 +433,12 @@ global with sharing class RollupService
 			}
 			rollupsByParentId.add(rollupSummaryScheduleItem);
 		}
-			
+
 		// Update master records
 		List<LookupRollupSummaryLog__c> rollupSummaryLogs = new List<LookupRollupSummaryLog__c>();
 		List<SObject> masterRecordList = masterRecords.values();
 		List<Database.Saveresult> saveResults = updateRecords(masterRecordList, false, false);
-		
+
 		// Log errors to the summary log
 		Integer masterRecordIdx = 0;
 		for(Database.Saveresult saveResult : saveResults)
@@ -465,18 +465,18 @@ global with sharing class RollupService
 				if(!masterRecordDeletionError) {
 					rollupSummaryLogs.add(logEntry);
 					// Remove from scheduled items to be deleted to allow a retry
-					rollupSummaryScheduleItemsByParentId.remove(masterRecordList[masterRecordIdx].Id);					
+					rollupSummaryScheduleItemsByParentId.remove(masterRecordList[masterRecordIdx].Id);
 				}
 			}
 			masterRecordIdx++;
 		}
-			
+
 		// Insert any logs for master records that failed to update (upsert to only show last message per parent)
 		upsert rollupSummaryLogs ParentId__c;
-		
+
 		// Delete any old logs entries for master records that have now been updated successfully
 		delete [select Id from LookupRollupSummaryLog__c where ParentId__c in :rollupSummaryScheduleItemsByParentId.keySet()];
-		
+
 		// Delete any schedule items for successfully updated master records
 		List<LookupRollupSummaryScheduleItems__c> scheduleItemsToDelete = new List<LookupRollupSummaryScheduleItems__c>();
 		for(List<LookupRollupSummaryScheduleItems__c> scheduleItems : rollupSummaryScheduleItemsByParentId.values())
@@ -489,24 +489,24 @@ global with sharing class RollupService
 	 *
 	 * @param lookups Lookup to calculate perform
 	 * @param childRecords Child records being modified
-	 **/ 
+	 **/
 	public static void updateMasterRollups(Set<String> lookupIds, Set<Id> masterRecordIds)
-	{		
+	{
 		// Process rollup
 		List<RollupSummary> lookups = new RollupSummariesSelector().selectById(lookupIds);
 		Map<Id, SObject> masterRecords = new Map<Id, SObject>();
-		List<LREngine.Context> ctxs = createLREngineContexts(lookups);		
+		List<LREngine.Context> ctxs = createLREngineContexts(lookups);
 		Set<Id> ctxMasterIds = new Set<Id>();
 		for(LREngine.Context ctx : ctxs)
 		{
-			// Produce a set of master Id's applicable to this context (parent only)			
+			// Produce a set of master Id's applicable to this context (parent only)
 			for(Id masterId : masterRecordIds)
 				if(masterId.getSObjectType() == ctx.master)
 					ctxMasterIds.add(masterId);
 			// Execute the rollup and process the resulting updated master records
-			for(SObject masterRecord : LREngine.rollup(ctx, ctxMasterIds)) 
+			for(SObject masterRecord : LREngine.rollup(ctx, ctxMasterIds))
 			{
-				// Skip master records without Id's (LREngine can return these where there was 
+				// Skip master records without Id's (LREngine can return these where there was
 				//	no related master records to children, for examlpe where a relationship is optional)
 				if(masterRecord.Id==null)
 					break;
@@ -516,12 +516,12 @@ global with sharing class RollupService
 					masterRecords.put(masterRecord.Id, masterRecord);
 				else
 					for(LREngine.RollupSummaryField fieldToRoll : ctx.fieldsToRoll)
-						existingRecord.put(fieldToRoll.master.getSObjectField(), 
+						existingRecord.put(fieldToRoll.master.getSObjectField(),
 							masterRecord.get(fieldToRoll.master.getSObjectField()));
-			}			
+			}
 		}
 
-		// Master records to update		
+		// Master records to update
 		List<SObject> masterRecordList = masterRecords.values();
 
 		// The following optimisation currently only works if processing a single rollup (parent)
@@ -532,10 +532,10 @@ global with sharing class RollupService
 			for(LREngine.RollupSummaryField fieldToRoll : ctx.fieldsToRoll) {
 				masterRecordQuery.selectField(fieldToRoll.master.getSObjectField());
 			}
-			// https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/619			
+			// https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/619
 			masterRecordQuery.setCondition(
 				// It appears there is no Apex Describe to determine FOR UPDATE support
-				ctx.master == User.SObjectType ? 
+				ctx.master == User.SObjectType ?
 					'Id in :ctxMasterIds' : 'Id in :ctxMasterIds FOR UPDATE');
 			// Filter master records to update only if rollups have changed
 			Map<Id, SObject> currentMasterRecordsById = new Map<Id, SObject>(Database.query(masterRecordQuery.toSOQL()));
@@ -549,7 +549,7 @@ global with sharing class RollupService
 					}
 					rollupValueChange = true;
 					break;
-				}			
+				}
 				if(rollupValueChange) {
 					newMasterRecordList.add(masterRecordToUpdate);
 				}
@@ -559,11 +559,11 @@ global with sharing class RollupService
 
 		// Update master records
 		List<Database.Saveresult> saveResults = updateRecords(masterRecordList, false, false);
-		
+
 		// Log errors to the summary log
 		Integer masterRecordIdx = 0;
 		Set<Id> masterRecordsUpdatedId = new Set<Id>();
-		List<LookupRollupSummaryLog__c> rollupSummaryLogs = new List<LookupRollupSummaryLog__c>();		
+		List<LookupRollupSummaryLog__c> rollupSummaryLogs = new List<LookupRollupSummaryLog__c>();
 		for(Database.Saveresult saveResult : saveResults)
 		{
 			// Errors?
@@ -586,10 +586,10 @@ global with sharing class RollupService
 			}
 			masterRecordIdx++;
 		}
-			
+
 		// Insert any logs for master records that failed to update (upsert to only show last message per parent)
 		upsert rollupSummaryLogs ParentId__c;
-		
+
 		// Delete any old logs entries for master records that have now been updated successfully
 		delete [select Id from LookupRollupSummaryLog__c where ParentId__c in :masterRecordsUpdatedId];
 	}
@@ -626,7 +626,7 @@ global with sharing class RollupService
 
     /**
      * Throws RollupServiceException if the Calculate Job is already running for the given lookup
-     **/    
+     **/
     @TestVisible
     private static void checkJobAlreadyRunning(String lookupId, String lookupName) {
         try {
@@ -634,7 +634,7 @@ global with sharing class RollupService
             insert new LookupRollupCalculateJob__c(LookupRollupSummaryId__c = (String) ((Id)lookupId));
         } catch (Exception e) {
             throw RollupServiceException.jobAlreadyRunning(lookupName);
-        }       
+        }
     }
 
 	/**
@@ -657,7 +657,7 @@ global with sharing class RollupService
 		rollupSummaries.onValidate();
 		RollupValidationException validationException = new RollupValidationException();
 		for(RollupSummary rollupSummaryRecord : rollupSummaries.Records) {
-			if(rollupSummaryRecord.Error!=null || 
+			if(rollupSummaryRecord.Error!=null ||
 			   rollupSummaryRecord.Fields.Errors.size() >0) {
 				RollupRecordValidationError recordError = new RollupRecordValidationError();
 				recordError.Error = rollupSummaryRecord.Error;
@@ -665,7 +665,7 @@ global with sharing class RollupService
 				validationException.RecordErrors.add(recordError);
 			}
 		}
-		if(validationException.RecordErrors.size()>0) 
+		if(validationException.RecordErrors.size()>0)
 			throw validationException;
 
 		return (List<SObject>) mdtRecords;
@@ -688,7 +688,7 @@ global with sharing class RollupService
 	}
 
 	/**
-	 * Process rollups for specified modes 
+	 * Process rollups for specified modes
 	 *
 	 * @param childRecords List of childRecords to process rollups against
 	 * @param existingRecords Map of existing records.  Pass null if no existing records are available.
@@ -700,7 +700,7 @@ global with sharing class RollupService
 	 *             3) if in existingRecords and newRecords and rollup FieldToAggregate__c has changed (update)
 	 *
 	 **/
-	@TestVisible	 
+	@TestVisible
 	private static void handleRollups(Map<Id, SObject> existingRecords, Map<Id, SObject> newRecords, Schema.SObjectType sObjectType, List<RollupSummaries.CalculationMode> calculationModes)
 	{
 		// make sure we have Maps to avoid conditional statements in loops below
@@ -723,11 +723,11 @@ global with sharing class RollupService
 			for(SObject existingRecord : existingRecords.values()) {
 				Id masterRecordId = (Id) existingRecord.get('MasterRecordId');
 				if(masterRecordId!=null) {
-					masterRecordIdsFromMerge.add(masterRecordId);					
+					masterRecordIdsFromMerge.add(masterRecordId);
 				}
-			}			
+			}
 		}
-	
+
 		// If this is a parent record merge operation, determine child object rollups to recalculate...
 		Boolean scheduleAllRollups = false;
 		Set<SObjectType> childObjects = new Set<SObjectType>();
@@ -738,7 +738,7 @@ global with sharing class RollupService
 			for(Schema.ChildRelationship childRelationship : childRelationships) {
 				childObjects.add(childRelationship.getChildSObject());
 			}
-			// Any rollups associated with these child objects will need to done in async, 
+			// Any rollups associated with these child objects will need to done in async,
 			//   as parent records cannot be updated realtime since the platform is also updating them
 			scheduleAllRollups = true;
 		}
@@ -747,7 +747,7 @@ global with sharing class RollupService
 		List<RollupSummary> lookups = describeRollups(childObjects, calculationModes);
 		if(lookups.isEmpty())
 			return; // Nothing to see here! :)
-			
+
 		// if records exist in both maps, then we need to go through change detection.
 		// Has anything changed on the child records in respect to the fields referenced on the lookup definition?
 		// Or does a record exist in one map but not the other
@@ -755,16 +755,16 @@ global with sharing class RollupService
 		{
 			// Master records to update
 			Set<Id> masterRecordIds = new Set<Id>();
-			 
+
 			// Set of field names from the child used in the rollup to search for changes on
-			Set<String> fieldsToSearchForChanges = new Set<String>(); 
-			Set<String> relationshipFields = new Set<String>(); 
+			Set<String> fieldsToSearchForChanges = new Set<String>();
+			Set<String> relationshipFields = new Set<String>();
 			// keep track of fields that should trigger a rollup to be processed
 			// this avoids having to re-parse RelationshipCriteria & OrderBy fields during field change detection
 			Map<Id, Set<String>> fieldsInvolvedInLookup = new Map<Id, Set<String>>();
 			for(RollupSummary lookup : lookups)
 			{
-				Set<String> lookupFields = new Set<String>();				
+				Set<String> lookupFields = new Set<String>();
 				lookupFields.add(lookup.FieldToAggregate);
 				if(!String.isBlank(lookup.RelationshipCriteriaFields)) {
 					for(String criteriaField : lookup.RelationshipCriteriaFields.split('[\r\n]+')) {
@@ -796,20 +796,20 @@ global with sharing class RollupService
 				// add relationship field to master list of relationship fields
 				relationshipFields.add(lookup.RelationShipField);
 			}
-			
+
 			// merge all record Id's
 			Set<Id> mergedRecordIds = new Set<Id>(existingRecords.keySet());
 			mergedRecordIds.addAll(newRecords.keySet());
 
 			// Determine if a a field referenced on the lookup has changed and thus if the lookup itself needs recalculating
-			Set<String> fieldsChanged = new Set<String>();  
+			Set<String> fieldsChanged = new Set<String>();
 			for(Id recordId : mergedRecordIds)
 			{
 				// keep track of whether or not this child has changed in any of the fields involved in
 				// lookups that are NOT relationship fields themselves.  We'll check relationship fields
-				// separately to avoid unnecessary rollups firing on master records that don't require updating				
+				// separately to avoid unnecessary rollups firing on master records that don't require updating
 				Boolean nonRelationshipFieldsChanged = false;
-							
+
 				// Determine if any of the fields referenced on our selected rollups have changed on this record
 				for(String fieldToSearch : fieldsToSearchForChanges)
 				{
@@ -829,9 +829,9 @@ global with sharing class RollupService
 						nonRelationshipFieldsChanged = true;
 					}
 				}
-				
+
 				// iterate relationship fields looking and track old/new master id
-				// if there were changes to the relationship field itself or any 
+				// if there were changes to the relationship field itself or any
 				// other fields involved in a lookup
 				for(String relationshipField : relationshipFields)
 				{
@@ -856,7 +856,7 @@ global with sharing class RollupService
 					}
 
 					// if relationship field itself changed or if change in another non-relationship field
-					// Add both old and new value to master record Id list for relationship fields 
+					// Add both old and new value to master record Id list for relationship fields
 					// to ensure old and new parent master records are updated (re-parenting)
 					if (addMasterIds)
 					{
@@ -867,9 +867,9 @@ global with sharing class RollupService
 					}
 				}
 			}
-			
+
 			// Build a revised list of lookups to process that includes only where fields used in the rollup have changed
-			List<RollupSummary> lookupsToProcess = new List<RollupSummary>(); 
+			List<RollupSummary> lookupsToProcess = new List<RollupSummary>();
 			for(RollupSummary lookup : lookups)
 			{
 				// Are any of the changed fields used by this lookup?
@@ -883,13 +883,13 @@ global with sharing class RollupService
 				}
 			}
 			lookups = lookupsToProcess;
-			
-			// Rollup child records and update master records 
+
+			// Rollup child records and update master records
 			if(lookupsToProcess.size()>0)
 				updateRecords(updateMasterRollupsTrigger(lookups, masterRecordIds, false), false, true);
 			return;
 		}
-			
+
 		// Rollup whichever side has records and update master records
 		// only one map should have records at this point
 		Boolean isDeleting = newRecords.isEmpty();
@@ -906,7 +906,7 @@ global with sharing class RollupService
 							continue;
 						}
 						masterRecordIds.add(masterRecordId);
-					}					
+					}
 				}
 			}
 		}
@@ -914,28 +914,28 @@ global with sharing class RollupService
 		// Process the rollups and update the master records
 		updateRecords(
 			updateMasterRollupsTrigger(lookups, masterRecordIds, scheduleAllRollups), false, true);
-	}	
-	
+	}
+
 	/**
 	 * Method wraps the LREngine.rolup method, provides context via the lookups described in RollupSummary
 	 *
 	 * @param lookups Lookup to calculate perform
 	 * @param childRecords Child records being modified
 	 * @returns Array of master records containing the updated rollups, calling code must perform update DML operation
-	 **/ 
+	 **/
 	private static List<SObject> updateMasterRollupsTrigger(List<RollupSummary> lookups, Set<Id> masterRecordIds, Boolean scheduleAllRollups)
 	{
-		// Process lookups, 
-		//    Realtime & Developer are added to a list for later LRE context creation and processing, 
+		// Process lookups,
+		//    Realtime & Developer are added to a list for later LRE context creation and processing,
 		//    Scheduled result in parent Id's being emitted to scheduled item object for later processing
         Map<String, Schema.SObjectType> gd = Schema.getGlobalDescribe();
-        List<RollupSummary> runnowLookups = new List<RollupSummary>();      
-        List<LookupRollupSummaryScheduleItems__c> scheduledItems = new List<LookupRollupSummaryScheduleItems__c>(); 
-        List<LookupRollupSummaryScheduleItems__c> scheduledItemsForMDTs = new List<LookupRollupSummaryScheduleItems__c>(); 
+        List<RollupSummary> runnowLookups = new List<RollupSummary>();
+        List<LookupRollupSummaryScheduleItems__c> scheduledItems = new List<LookupRollupSummaryScheduleItems__c>();
+        List<LookupRollupSummaryScheduleItems__c> scheduledItemsForMDTs = new List<LookupRollupSummaryScheduleItems__c>();
         for(RollupSummary lookup : lookups)
         {
             if(lookup.CalculationMode == RollupSummaries.CalculationMode.Scheduled.name() || scheduleAllRollups)
-            {       
+            {
             	// For polymoprhic relationships the master Id list maybe mixed types, associated with the correct rollup
                 SObjectType parentType = gd.get(lookup.ParentObject);
                 if(parentType==null)
@@ -948,13 +948,13 @@ global with sharing class RollupService
 	                    scheduledItem.Name = parentId;
 	                    scheduledItem.LookupRollupSummary2__c = lookup.Id;
 	                    scheduledItem.ParentId__c = parentId;
-	                    scheduledItem.QualifiedParentID__c = parentId + '#' + lookup.Id; 
+	                    scheduledItem.QualifiedParentID__c = parentId + '#' + lookup.Id;
 	                    scheduledItems.add(scheduledItem);
 	                    if(lookup.Record instanceof LookupRollupSummary2__mdt) {
-	                 		scheduledItemsForMDTs.add(scheduledItem);   	
+	                 		scheduledItemsForMDTs.add(scheduledItem);
 	                    }
 	                }
-                }                   
+                }
             }
             else if(lookup.CalculationMode == RollupSummaries.CalculationMode.Realtime.name() ||
             	lookup.CalculationMode == RollupSummaries.CalculationMode.Developer.name())
@@ -968,18 +968,18 @@ global with sharing class RollupService
         upsert scheduledItems QualifiedParentID__c;
 
 		// Process each context (parent child relationship) and its associated rollups
-		Map<Id, SObject> masterRecords = new Map<Id, SObject>();		
+		Map<Id, SObject> masterRecords = new Map<Id, SObject>();
 		for(LREngine.Context ctx : createLREngineContexts(runnowLookups))
 		{
-			// Produce a set of master Id's applicable to this context (parent only)			
+			// Produce a set of master Id's applicable to this context (parent only)
 			Set<Id> ctxMasterIds = new Set<Id>();
 			for(Id masterId : masterRecordIds)
 				if(masterId.getSObjectType() == ctx.master)
 					ctxMasterIds.add(masterId);
 			// Execute the rollup and process the resulting updated master records
-			for(SObject masterRecord : LREngine.rollup(ctx, ctxMasterIds)) 
+			for(SObject masterRecord : LREngine.rollup(ctx, ctxMasterIds))
 			{
-				// Skip master records without Id's (LREngine can return these where there was 
+				// Skip master records without Id's (LREngine can return these where there was
 				//	no related master records to children, for examlpe where a relationship is optional)
 				if(masterRecord.Id==null)
 					break;
@@ -989,22 +989,22 @@ global with sharing class RollupService
 					masterRecords.put(masterRecord.Id, masterRecord);
 				else
 					for(LREngine.RollupSummaryField fieldToRoll : ctx.fieldsToRoll)
-						existingRecord.put(fieldToRoll.master.getSObjectField(), 
+						existingRecord.put(fieldToRoll.master.getSObjectField(),
 							masterRecord.get(fieldToRoll.master.getSObjectField()));
-			}			
+			}
 		}
-			
+
 		// Return distinct set of master records will all rollups from all contexts present
-		return masterRecords.values();					
+		return masterRecords.values();
 	}
-	
+
 	/**
 	 * Queries for the defined rollups for the given child object type
 	 *
 	 * @returns List of rollup summary definitions
 	 **/
 	private static List<RollupSummary> describeRollups(Set<SObjectType> childObjectTypes, List<RollupSummaries.CalculationMode> calculationModes)
-	{	
+	{
 		// Query applicable lookup definitions
 		Set<String> childNames = new Set<String>();
 		for(SObjectType sobjectType : childObjectTypes) {
@@ -1012,25 +1012,25 @@ global with sharing class RollupService
 		}
 		List<RollupSummary> lookups =
 			new RollupSummariesSelector(false).selectActiveByChildObject(
-				calculationModes, 
+				calculationModes,
 				childNames);
-		return lookups;		
+		return lookups;
 	}
-		
+
 	/**
 	 * Method takes a list of Lookups and creates the most optimum list of LREngine.Context's to execute
 	 **/
 	private static List<LREngine.Context> createLREngineContexts(List<RollupSummary> lookups)
-	{ 
+	{
 		// list of contexts generated
 		List<LREngine.Context> engineContexts = new List<LREngine.Context>();
-		// map of context criteria (except for order by) to a map of orderby with context		
-		Map<String, Map<String, LREngine.Context>> engineCtxByParentRelationship = 
+		// map of context criteria (except for order by) to a map of orderby with context
+		Map<String, Map<String, LREngine.Context>> engineCtxByParentRelationship =
 			new Map<String, Map<String, LREngine.Context>>();
 		// list of rollupsummaryfields that do not have a specific orderby
 		List<LookupRollupSummaryWrapper> noOrderByLookupWrappers = new List<LookupRollupSummaryWrapper>();
-		Map<Id, LookupRollupSummaryScheduleItems__c> scheduledItems = 
-			new Map<Id, LookupRollupSummaryScheduleItems__c>(); 
+		Map<Id, LookupRollupSummaryScheduleItems__c> scheduledItems =
+			new Map<Id, LookupRollupSummaryScheduleItems__c>();
 		for(RollupSummary lookup : lookups)
 		{
 			// if no order is specified, we'll defer context identification until after we build contexts for
@@ -1051,18 +1051,18 @@ global with sharing class RollupService
 				}
 				String orderBy = lookupWrapper.OrderByClause; // this will be the FieldToOrderBy__c from the RollupSummary
 				// Lowering case on Describable fields is only required for Legacy purposes since RollupSummary records
-				// will be updated with describe names on insert/update moving forward.				
+				// will be updated with describe names on insert/update moving forward.
 				String orderByKey = orderBy.toLowerCase();
 				// obtain the context for this orderby key
 				LREngine.Context lreContext = lreContextByOrderBy.get(orderByKey);
 				// if not context yet, create one
 				if(lreContext==null)
-				{								
+				{
 					// Construct LREngine.Context
 					lreContext = createContext(lookupWrapper);
 					lreContextByOrderBy.put(orderByKey, lreContext);
 					engineContexts.add(lreContext);
-				}				
+				}
 				// Add the rollup summary field to the context
 				lreContext.add(lookupWrapper.RollupSummaryField);
 			}
@@ -1077,7 +1077,7 @@ global with sharing class RollupService
 			for (LookupRollupSummaryWrapper lookupWrapper :noOrderByLookupWrappers)
 			{
 				// Note that context key here will not include the order by
-				String contextKey = getContextKey(lookupWrapper);			
+				String contextKey = getContextKey(lookupWrapper);
 				// obtain the map of orderby to context based on contextKey
 				Map<String, LREngine.Context> lreContextByOrderBy = engineCtxByParentRelationship.get(contextKey);
 				// if we don't have a map yet, create it
@@ -1087,17 +1087,17 @@ global with sharing class RollupService
 				}
 
 				LREngine.Context lreContext = null;
-				if (lreContextByOrderBy.isEmpty()) 
+				if (lreContextByOrderBy.isEmpty())
 				{
-					// if we do not have any contexts yet then create one					
+					// if we do not have any contexts yet then create one
 					// when created, the OrderBy on the context will be set null since no order by was specified
 					// Construct LREngine.Context
 					lreContext = createContext(lookupWrapper);
 					// ensure key is lowered
 					lreContextByOrderBy.put('####NOORDERBY####', lreContext);
 					engineContexts.add(lreContext);
-				} 
-				else 
+				}
+				else
 				{
 					// since no orderby was specified we can execute in a non-deterministic manner
 					// so for that reason we'll just grab the first one
@@ -1108,7 +1108,7 @@ global with sharing class RollupService
 				}
 
 				// Add the rollup summary field to the context
-				lreContext.add(lookupWrapper.RollupSummaryField);				
+				lreContext.add(lookupWrapper.RollupSummaryField);
 			}
 		}
 
@@ -1119,12 +1119,12 @@ global with sharing class RollupService
 	{
 		return new LREngine.Context(
 						lookupWrapper.ParentObjectType, // parent object
-	                    lookupWrapper.ChildObjectType,  // child object                    
+	                    lookupWrapper.ChildObjectType,  // child object
 	                    lookupWrapper.RelationshipField.getDescribe(), // relationship field name
 	                    lookupWrapper.Lookup.RelationShipCriteria,
 	                    lookupWrapper.SharingMode,
 	                    lookupWrapper.OrderByClause,
-	                    lookupWrapper.AggregateAllRows);		
+	                    lookupWrapper.AggregateAllRows);
 	}
 
 	private static SObjectType getSObjectType(String sObjectName)
@@ -1141,10 +1141,10 @@ global with sharing class RollupService
 
 	private class LookupRollupSummaryWrapper
 	{
-		public RollupSummary Lookup;		
+		public RollupSummary Lookup;
 		public Schema.SObjectType ParentObjectType;
 		public Schema.SObjectType ChildObjectType;
-		public Schema.SObjectField FieldToAggregate;		
+		public Schema.SObjectField FieldToAggregate;
 		public Schema.SObjectField RelationshipField;
 		public Schema.SObjectField AggregateResultField;
 		public Boolean AggregateAllRows;
@@ -1176,7 +1176,7 @@ global with sharing class RollupService
             throw RollupServiceException.invalidRollup(lookup, 'Aggregate Result Field: ' + lookup.AggregateResultField);
 
 		// Summary field definition used by LREngine
-		LREngine.RollupSummaryField rsf = 
+		LREngine.RollupSummaryField rsf =
             new LREngine.RollupSummaryField(
 				aggregateResultField.getDescribe(),
 				fieldToAggregate.getDescribe(),
@@ -1213,14 +1213,14 @@ global with sharing class RollupService
 		// Ideally this would not be needed to save CPU cycles but including to ensure context is properly re-used when possible for
 		// rollups that have not been updated/inserted after the insert/update enhancement is applied
 		// Unable to lower RelationShipCriteria__c because of field value case-(in)sensitivity configuration
-		return  (lookupWrapper.Lookup.ParentObject.toLowerCase() + '#' + 
-			     lookupWrapper.Lookup.RelationshipField.toLowerCase() + '#' + 
-			     lookupWrapper.Lookup.RelationShipCriteria + '#' + 
-			     rsfType + '#' + 
+		return  (lookupWrapper.Lookup.ParentObject.toLowerCase() + '#' +
+			     lookupWrapper.Lookup.RelationshipField.toLowerCase() + '#' +
+			     lookupWrapper.Lookup.RelationShipCriteria + '#' +
+			     rsfType + '#' +
 			     lookupWrapper.SharingMode + '#' +
 			     lookupWrapper.AggregateAllRows);
 	}
-	
+
 	/**
 	 * Wrapper around DML allowing with or without sharing to be applied and all or nothing exception handling
 	 **/
@@ -1230,16 +1230,16 @@ global with sharing class RollupService
 			new UpdateWithSharing(masterRecords).updateRecords(allOrNothing) :
 			new UpdateWithoutSharing(masterRecords).updateRecords(allOrNothing);
 	}
-	
-	private virtual class Updater	
+
+	private virtual class Updater
 	{
 		protected List<SObject> masterRecords;
-		
+
 		public Updater(List<SObject> masterRecords)
 		{
-			this.masterRecords = masterRecords;	
+			this.masterRecords = masterRecords;
 		}
-				
+
 		public virtual List<Database.Saveresult> updateRecords(boolean allOrNothing)
 		{
 			// sort (selection sort) masterRecords to avoid having more than 10 chunks in a single database operation
@@ -1270,9 +1270,9 @@ global with sharing class RollupService
                             continue;
                         } else {
                             break;
-                        }                                    			            
+                        }
 			        }
-			        throwException = rowIdx < e.getNumDml(); 			     
+			        throwException = rowIdx < e.getNumDml();
 			    }
 			    if(!throwException) {
 	                // Swallow an exception describing failure to update parent rows that have been deleted
@@ -1280,26 +1280,26 @@ global with sharing class RollupService
                     return new List<Database.Saveresult>();
 			    }
                 // Throw on as normal
-                throw e;        
+                throw e;
 			}
-		}						
+		}
 	}
-	
-	private with sharing class UpdateWithSharing extends Updater 
-	{ 
-		public UpdateWithSharing(List<SObject> masterRecords) 
-			{ super(masterRecords); }
-				
-		public override List<Database.Saveresult> updateRecords(boolean allOrNothing) 
-			{ return super.updateRecords(allOrNothing); }		
-	}
-	
-	private without sharing class UpdateWithoutSharing extends Updater 
+
+	private with sharing class UpdateWithSharing extends Updater
 	{
-		public UpdateWithoutSharing(List<SObject> masterRecords) 
+		public UpdateWithSharing(List<SObject> masterRecords)
 			{ super(masterRecords); }
-		
-		public override List<Database.Saveresult> updateRecords(boolean allOrNothing) 
-			{ return super.updateRecords(allOrNothing); }		
+
+		public override List<Database.Saveresult> updateRecords(boolean allOrNothing)
+			{ return super.updateRecords(allOrNothing); }
+	}
+
+	private without sharing class UpdateWithoutSharing extends Updater
+	{
+		public UpdateWithoutSharing(List<SObject> masterRecords)
+			{ super(masterRecords); }
+
+		public override List<Database.Saveresult> updateRecords(boolean allOrNothing)
+			{ return super.updateRecords(allOrNothing); }
 	}
 }

--- a/force-app/main/classes/RollupService.cls
+++ b/force-app/main/classes/RollupService.cls
@@ -633,14 +633,16 @@ global with sharing class RollupService
             // This object has a unique constraint over LookupRollupSummaryId__c
             insert new LookupRollupCalculateJob__c(LookupRollupSummaryId__c = (String) ((Id)lookupId));
 		} catch (Exception e) {
-			throwServiceException(e.getStatusCode(), lookupName);
-        }
+			throwServiceException(e, lookupName);
+		}
     }
 
 	@TestVisible
-	private static void throwServiceException(StatusCode exceptionStatusCode, String lookupName) {
-		if (exceptionStatusCode == StatusCode.STORAGE_LIMIT_EXCEEDED) {
-			throw RollupServiceException.missingStorageForJobRecord();
+	private static void throwServiceException(Exception e, String lookupName) {
+		if (e.getTypeName().toLowerCase() == 'dmlexception') {
+			if (((DMLException) e).getDmlType(0) == StatusCode.STORAGE_LIMIT_EXCEEDED) {
+				throw RollupServiceException.missingStorageForJobRecord();
+			}
 		}
 		throw RollupServiceException.jobAlreadyRunning(lookupName);
 	}

--- a/force-app/main/classes/RollupService.cls
+++ b/force-app/main/classes/RollupService.cls
@@ -632,10 +632,18 @@ global with sharing class RollupService
         try {
             // This object has a unique constraint over LookupRollupSummaryId__c
             insert new LookupRollupCalculateJob__c(LookupRollupSummaryId__c = (String) ((Id)lookupId));
-        } catch (Exception e) {
-            throw RollupServiceException.jobAlreadyRunning(lookupName);
+		} catch (Exception e) {
+			throwServiceException(e.getStatusCode(), lookupName);
         }
     }
+
+	@TestVisible
+	private static void throwServiceException(StatusCode exceptionStatusCode, String lookupName) {
+		if (exceptionStatusCode == StatusCode.STORAGE_LIMIT_EXCEEDED) {
+			throw RollupServiceException.missingStorageForJobRecord();
+		}
+		throw RollupServiceException.jobAlreadyRunning(lookupName);
+	}
 
 	/**
 	 * Validates records (currenyly only Custom Metadata based ones)

--- a/force-app/main/classes/RollupServiceException.cls
+++ b/force-app/main/classes/RollupServiceException.cls
@@ -2,22 +2,22 @@
  * Copyright (c), Andrew Fawcett
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  *   are permitted provided that the following conditions are met:
  *
- * - Redistributions of source code must retain the above copyright notice, 
+ * - Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice, 
- *      this list of conditions and the following disclaimer in the documentation 
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
  *      and/or other materials provided with the distribution.
- * - Neither the name of the Andrew Fawcett, nor the names of its contributors 
- *      may be used to endorse or promote products derived from this software without 
+ * - Neither the name of the Andrew Fawcett, nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
  *      specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
- *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
- *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
- *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
  *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
@@ -27,16 +27,16 @@
 /**
  * Generic exception class used by methods on the RollupService
  **/
-public class RollupServiceException extends Exception 
+public class RollupServiceException extends Exception
 {
 	/**
 	 * Generic exception when aspects of the rollup summary definition are found to be in error at runtime
 	 **/
 	public static RollupServiceException invalidRollup(RollupSummary lookup, String configInvalid)
-	{ 
+	{
 		return new RollupServiceException('Lookup Rollup Summary  \'' + lookup.Name + '\' is invalid, your org configuration may have changed (' + configInvalid + ').');
 	}
-	
+
 	/**
 	 * Unable to find the given lookup
 	 **/
@@ -44,20 +44,28 @@ public class RollupServiceException extends Exception
 	{
 		return new RollupServiceException('Invalid rollup ' + lookupId + ' not found.');
 	}
-	
+
 	/**
-	 * Job alraedy executed to recalculate rollup 
+	 * Job alraedy executed to recalculate rollup
 	 **/
 	public static RollupServiceException jobAlreadyRunning(String name)
 	{
 		return new RollupServiceException('A calculate job for rollup \'' + name + '\' is already executing. If you suspect it is not aleady running try clearing the applicable record from the Lookup Rollup Calculate Jobs tab and try again.');
 	}
-	
+
 	/**
 	 * Jobs executing
 	 **/
 	public static RollupServiceException jobsExecuting(String className)
 	{
 		return new RollupServiceException('A previous Declarative Rollup Summary scheduled job \'' + className + '\' is still running, this scheduled execution will not occur.');
+	}
+
+	/**
+	 * Missing space for rollup record
+	 **/
+	public static RollupServiceException missingStorageForJobRecord()
+	{
+		return new RollupServiceException('Your organization has run out of space for the rollup job record to be inserted. Please clean up some space before running the calculate job.');
 	}
 }

--- a/force-app/main/classes/RollupServiceTest.cls
+++ b/force-app/main/classes/RollupServiceTest.cls
@@ -1977,7 +1977,9 @@ private with sharing class RollupServiceTest
 	static void testExceptionThrowing()
 	{
 		try {
-			RollupService.throwServiceException(StatusCode.STORAGE_LIMIT_EXCEEDED, 'LookupName');
+			// cannot force a 'STORAGE_LIMIT_EXCEEDED' exception
+			// but at least we can test the method call
+			RollupService.throwServiceException(new RollupServiceException('test'), 'LookupName');
 			System.assert(false);
 		} catch (RollupServiceException e) {
 			System.assert(true);

--- a/force-app/main/classes/RollupServiceTest.cls
+++ b/force-app/main/classes/RollupServiceTest.cls
@@ -2,22 +2,22 @@
  * Copyright (c) 2013, Andrew Fawcett
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or without modification, 
+ * Redistribution and use in source and binary forms, with or without modification,
  *   are permitted provided that the following conditions are met:
  *
- * - Redistributions of source code must retain the above copyright notice, 
+ * - Redistributions of source code must retain the above copyright notice,
  *      this list of conditions and the following disclaimer.
- * - Redistributions in binary form must reproduce the above copyright notice, 
- *      this list of conditions and the following disclaimer in the documentation 
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ *      this list of conditions and the following disclaimer in the documentation
  *      and/or other materials provided with the distribution.
- * - Neither the name of the Andrew Fawcett, nor the names of its contributors 
- *      may be used to endorse or promote products derived from this software without 
+ * - Neither the name of the Andrew Fawcett, nor the names of its contributors
+ *      may be used to endorse or promote products derived from this software without
  *      specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
- *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES 
- *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
- *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ *  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ *  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
  *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
  *  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  *  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
@@ -28,10 +28,10 @@
  * Tests the RollupService methods, note the LREngine is test independently via TestLREngine
  **/
 @IsTest
-private with sharing class RollupServiceTest 
-{		
+private with sharing class RollupServiceTest
+{
 	static Schema.SObjectField ACCOUNT_SLA_EXPIRATION_DATE;
-	static Schema.SObjectField ACCOUNT_NUMBER_OF_LOCATIONS;		
+	static Schema.SObjectField ACCOUNT_NUMBER_OF_LOCATIONS;
 	static
 	{
 		// Dynamically resolve these fields, if they are not present when the test runs, the test will return as passed to avoid failures in subscriber org when packaged
@@ -42,27 +42,27 @@ private with sharing class RollupServiceTest
 
 	private testmethod static void testSingleSumRollup()
 	{
-		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 600, RollupSummaries.AggregateOperation.Sum, null);	
+		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 600, RollupSummaries.AggregateOperation.Sum, null);
 	}
 
 	private testmethod static void testSingleMaxRollup()
 	{
-		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 250, RollupSummaries.AggregateOperation.Max, null);	
+		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 250, RollupSummaries.AggregateOperation.Max, null);
 	}
 
 	private testmethod static void testSingleMinRollup()
 	{
-		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 50, RollupSummaries.AggregateOperation.Min, null);	
+		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 50, RollupSummaries.AggregateOperation.Min, null);
 	}
 
 	private testmethod static void testSingleAvgRollup()
 	{
-		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 150, RollupSummaries.AggregateOperation.Avg, null);	
+		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 150, RollupSummaries.AggregateOperation.Avg, null);
 	}
 
 	private testmethod static void testSingleCountRollup()
 	{
-		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 4, RollupSummaries.AggregateOperation.Count, null);	
+		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 4, RollupSummaries.AggregateOperation.Count, null);
 	}
 
 	private testmethod static void testSingleCountDistinctRollup()
@@ -72,28 +72,28 @@ private with sharing class RollupServiceTest
 
 	private testmethod static void testSingleSumRollupConditional()
 	{
-		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 500, RollupSummaries.AggregateOperation.Sum, 'Amount > 200');	
+		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 500, RollupSummaries.AggregateOperation.Sum, 'Amount > 200');
 	}
-	
+
 	private testmethod static void testMultiRollup()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
 
 		// Test data
 		List<Decimal> rollups = new List<Decimal> { 250, 250, 50, 50 };
-					
+
 		// Test data for rollup A
 		Decimal expectedResultA = 500;
-		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum;
 		String conditionA = 'Amount > 200';
 
 		// Test data for rollup B
 		Decimal expectedResultB = 4;
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count;
 		String conditionB = null;
-		
+
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -122,13 +122,13 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		for(Decimal rollupValue : rollups)
 		{
 			Opportunity opp = new Opportunity();
@@ -137,36 +137,36 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
-		
+
 		// Assert rollup
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);			
-		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));			
+		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
+		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
 	}
-	
+
 	private testmethod static void testMultiRollupSumAndAvg()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
 
 		// Test data
 		List<Decimal> rollups = new List<Decimal> { 250, 250, 50, 50 };
-					
+
 		// Test data for rollup A
 		Decimal expectedResultA = 600;
-		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum;
 		String conditionA = null;
 
 		// Test data for rollup B
 		Decimal expectedResultB = 150;
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Avg; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Avg;
 		String conditionB = null;
-		
+
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'Total Opportunities into Annual Revenue on Account';
@@ -195,13 +195,13 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		for(Decimal rollupValue : rollups)
 		{
 			Opportunity opp = new Opportunity();
@@ -210,36 +210,36 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
-		
+
 		// Assert rollup
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);			
-		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));			
+		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
+		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
 	}
 
 	private testmethod static void testMultiRollupNoConditions()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
 
 		// Test data
 		List<Decimal> rollups = new List<Decimal> { 10, 20, 30, 40 };
-					
+
 		// Test data for rollup A
 		Decimal expectedResultA = 160;
-		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Max; 
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Max;
 		String conditionA = null;
 
 		// Test data for rollup B
 		Decimal expectedResultB = 4;
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count;
 		String conditionB = null;
-		
+
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'Max Opportunities Amount';
@@ -268,13 +268,13 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryB, rollupSummaryA };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		Integer rollupIdx = 0;
 		for(Decimal rollupValue : rollups)
 		{
@@ -285,19 +285,19 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue * rollupIdx;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
-		
+
 		// Assert rollup
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);			
-		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));			
+		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
+		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
 	}
 
 	private testmethod static void testCountByType()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
@@ -307,7 +307,7 @@ private with sharing class RollupServiceTest
 
 		// Test data for rollup B
 		Decimal expectedResultB = 2;
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count;
 		String conditionB = null;
 
 		// Configure rollup B
@@ -325,13 +325,13 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryB };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		Integer rollupIdx = 0;
 		for(Decimal rollupValue : rollups)
 		{
@@ -343,19 +343,19 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue * rollupIdx;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
-		
+
 		// Assert rollup
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));			
+		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
 	}
 
 
 	private testmethod static void testCountById()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
@@ -365,7 +365,7 @@ private with sharing class RollupServiceTest
 
 		// Test data for rollup B
 		Decimal expectedResultB = 4;
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count;
 		String conditionB = null;
 
 		// Configure rollup B
@@ -383,13 +383,13 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryB };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		Integer rollupIdx = 0;
 		for(Decimal rollupValue : rollups)
 		{
@@ -400,41 +400,41 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue * rollupIdx;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
-		
+
 		// Assert rollup
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));			
+		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
 	}
-	
-	
+
+
 	private testmethod static void testMultiRollupWithTwoParents()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
 
 		// Test data
 		List<Decimal> rollups = new List<Decimal> { 250, 250, 50, 50 };
-					
+
 		// Test data for rollup A
 		Decimal expectedResultA = 500;
-		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum;
 		String conditionA = 'Amount > 200';
 
 		// Test data for rollup B
 		Decimal expectedResultB = 4;
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count;
 		String conditionB = null;
 
 		// Test data for rollup C
 		Decimal expectedResultC = 600;
-		RollupSummaries.AggregateOperation operationC = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationC = RollupSummaries.AggregateOperation.Sum;
 		String conditionC = null;
-		
+
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -476,7 +476,7 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB, rollupSummaryC };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
@@ -484,8 +484,8 @@ private with sharing class RollupServiceTest
 		insert account;
 		SObject camp = Schema.getGlobalDescribe().get('Campaign').newSObject();
 		camp.put('Name', 'Test Campaign');
-		insert camp; 
-		List<Opportunity> opps = new List<Opportunity>(); 
+		insert camp;
+		List<Opportunity> opps = new List<Opportunity>();
 		for(Decimal rollupValue : rollups)
 		{
 			Opportunity opp = new Opportunity();
@@ -496,41 +496,41 @@ private with sharing class RollupServiceTest
 			opp.Amount = rollupValue;
 			opp.TotalOpportunityQuantity = rollupValue;
 			opp.put('CampaignId', camp.Id);
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
-		
+
 		// Assert rollups
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);			
-		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));	
-		Id campId = camp.Id;		
+		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
+		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
+		Id campId = camp.Id;
 		SObject campResult = Database.query('select NumberSent from Campaign where Id = :campId');
-		System.assertEquals(expectedResultC, campResult.get('NumberSent'));			
+		System.assertEquals(expectedResultC, campResult.get('NumberSent'));
 	}
-	
+
 	private testmethod static void testMultiRollupWithTwoParentsTenChunks()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
 
 		// Test data
-		List<Decimal> rollups = new List<Decimal> { 
+		List<Decimal> rollups = new List<Decimal> {
 			1, 2, 3, 4, 5
 			,6, 7, 8, 9, 10
 			,11, 12, 13, 14, 15
 		};
-					
+
 		// Test data for rollup A
-		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum;
 		String conditionA = null;
 
 		// Test data for rollup B
-		RollupSummaries.AggregateOperation operationC = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationC = RollupSummaries.AggregateOperation.Sum;
 		String conditionB = null;
-		
+
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -559,12 +559,12 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
-		
+
 		// Test data
 		List<SObject> accountList = new List<SObject>();
 		List<SObject> campaignList = new List<SObject>();
 
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		Integer index = 0;
 		for(Decimal rollupValue : rollups) {
 			// add each Opportunity to a new Account/Campaign to produce chunking
@@ -587,7 +587,7 @@ private with sharing class RollupServiceTest
 			opp.put('CampaignId', campaignList[index].Id);
 			opps.add(opp);
 
-			index++;			
+			index++;
 		}
 		insert opps;
 
@@ -596,22 +596,22 @@ private with sharing class RollupServiceTest
 		for(Decimal rollupValue : rollups) {
 			Id accountId = accountList[index].Id;
 			Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-			System.assertEquals(rollupValue, accountResult.AnnualRevenue);			
-			
-			Id campId = campaignList[index].Id;		
+			System.assertEquals(rollupValue, accountResult.AnnualRevenue);
+
+			Id campId = campaignList[index].Id;
 			SObject campResult = Database.query('select NumberSent from Campaign where Id = :campId');
 			System.assertEquals(rollupValue, campResult.get('NumberSent'));
-			
-			index++;			
+
+			index++;
 		}
 	}
-	
+
 	private testmethod static void testSingleRollupWithoutRelation()
 	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
 		// Configure rollup
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -625,37 +625,37 @@ private with sharing class RollupServiceTest
 		rollupSummary.Active__c = true;
 		rollupSummary.CalculationMode__c = 'Realtime';
 		insert new List<LookupRollupSummary__c> { rollupSummary };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		Opportunity opp = new Opportunity(); 
+		Opportunity opp = new Opportunity();
 		opp.Name = 'Test Opportunity';
 		opp.StageName = 'Open';
 		opp.CloseDate = System.today();
 		opp.AccountId = null; // Note no relationship with an Account
 		opp.Amount = 100;
 		insert opp;
-		
+
 		// Assert rollup
 		System.assertEquals(0, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);
-		
+
 		// Do an update
 		opp.Amount = 101;
-		update opp;		
-		
+		update opp;
+
 		// Assert rollup
-		System.assertEquals(0, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);					
+		System.assertEquals(0, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);
 	}
-		
+
 	private testmethod static void testSingleRollupWithInsertThenDelete()
 	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
 		// Configure rollup
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -669,28 +669,28 @@ private with sharing class RollupServiceTest
 		rollupSummary.Active__c = true;
 		rollupSummary.CalculationMode__c = 'Realtime';
 		insert new List<LookupRollupSummary__c> { rollupSummary };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		Opportunity opp = new Opportunity(); 
+		Opportunity opp = new Opportunity();
 		opp.Name = 'Test Opportunity';
 		opp.StageName = 'Open';
 		opp.CloseDate = System.today();
 		opp.AccountId = account.Id;
 		opp.Amount = 100;
 		insert opp;
-		
+
 		// Assert rollup
 		System.assertEquals(100, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);
-		
+
 		// Delete Opportunity
 		delete opp;
-		
+
 		// Assert rollup
-		System.assertEquals(0, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);							
+		System.assertEquals(0, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);
 	}
 
 	private testmethod static void testSingleRollupWithInsertsThenDelete()
@@ -698,7 +698,7 @@ private with sharing class RollupServiceTest
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
 		// Configure rollup
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -712,14 +712,14 @@ private with sharing class RollupServiceTest
 		rollupSummary.Active__c = true;
 		rollupSummary.CalculationMode__c = 'Realtime';
 		insert new List<LookupRollupSummary__c> { rollupSummary };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
 		{
-			Opportunity opp = new Opportunity(); 
+			Opportunity opp = new Opportunity();
 			opp.Name = 'Test Opportunity';
 			opp.StageName = 'Open';
 			opp.CloseDate = System.today();
@@ -727,46 +727,46 @@ private with sharing class RollupServiceTest
 			opp.Amount = 100;
 			insert opp;
 		}
-		Opportunity opp = new Opportunity(); 
+		Opportunity opp = new Opportunity();
 		opp.Name = 'Test Opportunity';
 		opp.StageName = 'Open';
 		opp.CloseDate = System.today();
 		opp.AccountId = account.Id;
 		opp.Amount = 100;
 		insert opp;
-		
+
 		// Assert rollup
 		System.assertEquals(200, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);
-		
+
 		// Delete Opportunity
 		delete opp;
-		
+
 		// Assert rollup
-		System.assertEquals(100, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);							
+		System.assertEquals(100, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);
 	}
-	
+
 	private testmethod static void testRollupWithoutChanges()
 	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
 		// Perform standard test
 		testSingleRollup(new List<Decimal> { 250, 250, 50, 50 }, 600, RollupSummaries.AggregateOperation.Sum, null);
 		List<Opportunity> opps = [select Id from Opportunity];
-		
+
 		// Sample various limits prior to an update
 		Integer beforeQueries = Limits.getQueries();
 		Integer beforeRows = Limits.getQueryRows();
-		
+
 		// Update opportunities (no changes to the field being aggregted, thus no rollup processng)
 		update opps;
-		
+
 		// Assert no further limits have been used since the field to aggregate on the detail has not changed
 		System.assertEquals(beforeQueries + 1, Limits.getQueries()); // Only tolerate a query for the Lookup definition
 		System.assertEquals(beforeRows + 1, Limits.getQueryRows()); // Only tolerate a row for the Lookup definition
 	}
-	
+
 	private testmethod static void testLimitsConsumedWithConditions()
 	{
 		// Test supported?
@@ -774,21 +774,21 @@ private with sharing class RollupServiceTest
 			return;
 
 		// Disable the Account trigger for this test, its carefully caluculated test actuals are thrown when this is enabled as well
-		TestContext.AccountTestTriggerEnabled = false;	
+		TestContext.AccountTestTriggerEnabled = false;
 
 		// Test data
 		List<Decimal> rollups = new List<Decimal> { 250, 250, 50, 50 };
-					
+
 		// Test data for rollup A
 		Decimal expectedResultA = 500;
-		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum;
 		String conditionA = 'Amount > 200';
 
 		// Test data for rollup B
 		Decimal expectedResultB = 4;
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count;
 		String conditionB = null;
-		
+
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -817,13 +817,13 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		for(Decimal rollupValue : rollups)
 		{
 			Opportunity opp = new Opportunity();
@@ -832,7 +832,7 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
 
@@ -841,22 +841,22 @@ private with sharing class RollupServiceTest
 		// One query on Database.newQueryLocator (validation when insert rollup a)
 		// One query on Rollup object
 		// One query on Opportunity for rollup a
-		// One query on Opportunity for rollup b				
-		System.assertEquals(6, Limits.getQueries());	
-		
-		// One row for ApexTrigger (in the TestContext.isSupported method)		
+		// One query on Opportunity for rollup b
+		System.assertEquals(6, Limits.getQueries());
+
+		// One row for ApexTrigger (in the TestContext.isSupported method)
 		// One row for ApexTrigger
 		// Two rows for Rollup object
 		// Two rows for Opportunity for rollup a
 		// Four rows for Opportunity for rollup b
 		System.assertEquals(10, Limits.getQueryRows());
-				
+
 		// Assert rollup
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);			
+		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
 		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
-		
+
 		// Modify the opps, but only the Amount, this should result in only the Amount rollup executing
 		for(Opportunity opp : opps)
 			opp.Amount++;
@@ -865,41 +865,41 @@ private with sharing class RollupServiceTest
 		// + One query for the Account query above
 		// + One query on Rollup object
 		// + One query on Opportunity for rollup a
-		System.assertEquals(9, Limits.getQueries());	
+		System.assertEquals(9, Limits.getQueries());
 
-		// + One query for the Account query above		
+		// + One query for the Account query above
 		// + Two rows for Rollup object
 		// + Two rows for Opportunity for rollup a
 		System.assertEquals(15, Limits.getQueryRows());
 
 		// Assert rollup
 		accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultA + 2, accountResult.AnnualRevenue);			
-		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));								
+		System.assertEquals(expectedResultA + 2, accountResult.AnnualRevenue);
+		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
 	}
-	
+
 	private testmethod static void testLimitsConsumedWithoutConditions()
 	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-			
+
 		// Disable the Account trigger for this test, its carefully caluculated test actuals are thrown when this is enabled as well
-		TestContext.AccountTestTriggerEnabled = false;	
+		TestContext.AccountTestTriggerEnabled = false;
 
 		// Test data
 		List<Decimal> rollups = new List<Decimal> { 250, 250, 50, 50 };
-					
+
 		// Test data for rollup A
 		Decimal expectedResultA = 600;
-		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum;
 		String conditionA = null;
 
 		// Test data for rollup B
 		Decimal expectedResultB = 4;
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Count;
 		String conditionB = null;
-		
+
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -928,13 +928,13 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		for(Decimal rollupValue : rollups)
 		{
 			Opportunity opp = new Opportunity();
@@ -943,7 +943,7 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
 
@@ -951,20 +951,20 @@ private with sharing class RollupServiceTest
 		// One query on ApexTrigger (validation when inserting rollups)
 		// One query on Rollup object
 		// One query on Opportunity for both rollups
-		System.assertEquals(4, Limits.getQueries());	
-		
+		System.assertEquals(4, Limits.getQueries());
+
 		// One row for ApexTrigger (in the TestContext.isSupported method)
 		// One row for ApexTrigger
 		// Two rows for Rollup object
 		// Four rows for Opportunity for rollup a and b
 		System.assertEquals(8, Limits.getQueryRows());
-				
+
 		// Assert rollup
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);			
+		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
 		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
-		
+
 		// Modify the opps, but only the Amount, this should result in only the Amount rollup executing
 		for(Opportunity opp : opps)
 			opp.Amount++;
@@ -973,25 +973,25 @@ private with sharing class RollupServiceTest
 		// + One query for the Account query above
 		// + One query on Rollup object
 		// + One query on Opportunity for rollup a
-		System.assertEquals(7, Limits.getQueries());	
+		System.assertEquals(7, Limits.getQueries());
 
-		// + One query for the Account query above		
+		// + One query for the Account query above
 		// + Two rows for Rollup object
-		// + Four rows for Opportunity for rollup a and 
+		// + Four rows for Opportunity for rollup a and
 		System.assertEquals(15, Limits.getQueryRows());
 
 		// Assert rollup
 		accountResult = Database.query('select AnnualRevenue, NumberOfLocations__c from Account where Id = :accountId');
-		System.assertEquals(expectedResultA + 4, accountResult.AnnualRevenue);			
-		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));								
+		System.assertEquals(expectedResultA + 4, accountResult.AnnualRevenue);
+		System.assertEquals(expectedResultB, accountResult.get(ACCOUNT_NUMBER_OF_LOCATIONS));
 	}
-	
+
 	private static void testSingleRollup(List<Decimal> rollups, Decimal expectedResult, RollupSummaries.AggregateOperation operation, String condition)
-	{			 
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
-		
+
 		// Configure rollup
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
 		rollupSummary.Name = 'Total Opportunities greater than 200 into Annual Revenue on Account';
@@ -1005,13 +1005,13 @@ private with sharing class RollupServiceTest
 		rollupSummary.Active__c = true;
 		rollupSummary.CalculationMode__c = 'Realtime';
 		insert new List<LookupRollupSummary__c> { rollupSummary };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		for(Decimal rollupValue : rollups)
 		{
 			Opportunity opp = new Opportunity();
@@ -1020,33 +1020,33 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
-		
+
 		// Assert rollup
-		System.assertEquals(expectedResult, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);			
-	}	
+		System.assertEquals(expectedResult, [select AnnualRevenue from Account where Id = :account.Id].AnnualRevenue);
+	}
 
 	private testmethod static void testMultiRollupOfDifferentTypes()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
 
 		// Test data
 		List<Decimal> rollups = new List<Decimal> { 250, 250, 50, 50 };
-					
+
 		// Test data for rollup A
 		Decimal expectedResultA = 600;
-		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum; 
+		RollupSummaries.AggregateOperation operationA = RollupSummaries.AggregateOperation.Sum;
 		String conditionA = null;
 
 		// Test data for rollup B
 		String expectedResultB = 'Open,Open,Open,Open';
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate;
 		String conditionB = null;
-		
+
 		// Configure rollup A
 		LookupRollupSummary__c rollupSummaryA = new LookupRollupSummary__c();
 		rollupSummaryA.Name = 'Total Opportunities into Annual Revenue on Account';
@@ -1076,13 +1076,13 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
 		account.AnnualRevenue = 0;
 		insert account;
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		for(Decimal rollupValue : rollups)
 		{
 			Opportunity opp = new Opportunity();
@@ -1091,15 +1091,15 @@ private with sharing class RollupServiceTest
 			opp.CloseDate = System.today();
 			opp.AccountId = account.Id;
 			opp.Amount = rollupValue;
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
-		
+
 		// Assert rollup
 		Id accountId = account.Id;
 		Account accountResult = Database.query('select AnnualRevenue, Description from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);			
-		System.assertEquals(expectedResultB, accountResult.Description);			
+		System.assertEquals(expectedResultA, accountResult.AnnualRevenue);
+		System.assertEquals(expectedResultB, accountResult.Description);
 	}
 
 	/**
@@ -1148,7 +1148,7 @@ private with sharing class RollupServiceTest
 
 		// Insert rollup definitions
 		insert new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
-		
+
 		// Test data
 		Account account = new Account();
 		account.Name = 'Test Account';
@@ -1156,28 +1156,28 @@ private with sharing class RollupServiceTest
 		insert account;
 
 		Date today = System.today();
-		List<Opportunity> opps = new List<Opportunity>(); 
+		List<Opportunity> opps = new List<Opportunity>();
 		for (String opportunityName :opportunityData.keySet())
 		{
 			List<String> oppFieldValues = opportunityData.get(opportunityName).split(';');
 			Opportunity opp = new Opportunity();
 			opp.Name = opportunityName;
-			opp.AccountId = account.Id;			
+			opp.AccountId = account.Id;
 			opp.Amount = Decimal.valueOf(oppFieldValues[0]);
-			opp.CloseDate = today.addMonths(Integer.valueOf(oppFieldValues[1]));			
+			opp.CloseDate = today.addMonths(Integer.valueOf(oppFieldValues[1]));
 			opp.StageName = oppFieldValues[2];
-			opps.add(opp);			
+			opps.add(opp);
 		}
 		insert opps;
 
-		return account.Id;		
+		return account.Id;
 	}
 
 	/**
 	 * Test default behavior with different order by on each rollup
-	 */	 
+	 */
 	private testmethod static void testMultiRollupOfDifferentTypesDifferentOrderBy()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
@@ -1197,7 +1197,7 @@ private with sharing class RollupServiceTest
 
 		// Test data for rollup B
 		String expectedResultB = 'Steve,Kim,Charlie,Joe';
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate;
 		String orderByClauseB = Schema.SObjectType.Opportunity.fields.Amount.getName();
 
 		// generate rollups and data
@@ -1205,16 +1205,16 @@ private with sharing class RollupServiceTest
 
 		// Assert rollup
 		Account accountResult = Database.query('select Sic, Description from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.Sic);			
-		System.assertEquals(expectedResultB, accountResult.Description);			
+		System.assertEquals(expectedResultA, accountResult.Sic);
+		System.assertEquals(expectedResultB, accountResult.Description);
 	}
 
 	/**
 	 * Test default behavior with different order by containing multiple fields on each rollup
 	 * for Issue https://github.com/afawcett/declarative-lookup-rollup-summaries/issues/216
-	 */	 
+	 */
 	private testmethod static void testMultiRollupOfDifferentTypesDifferentMultipleFieldsOrderBy()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
@@ -1234,7 +1234,7 @@ private with sharing class RollupServiceTest
 
 		// Test data for rollup B
 		String expectedResultB = 'Kim,Joe,Charlie,Steve';
-		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate; 
+		RollupSummaries.AggregateOperation operationB = RollupSummaries.AggregateOperation.Concatenate;
 		String orderByClauseB = 'Amount ASC NULLS FIRST, CloseDate DESC NULLS FIRST, Name';
 
 		// generate rollups and data
@@ -1242,12 +1242,12 @@ private with sharing class RollupServiceTest
 
 		// Assert rollup
 		Account accountResult = Database.query('select Sic, Description from Account where Id = :accountId');
-		System.assertEquals(expectedResultA, accountResult.Sic);			
-		System.assertEquals(expectedResultB, accountResult.Description);			
-	}	
+		System.assertEquals(expectedResultA, accountResult.Sic);
+		System.assertEquals(expectedResultB, accountResult.Description);
+	}
 
 	private testmethod static void testPicklistRollup()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
@@ -1316,7 +1316,7 @@ private with sharing class RollupServiceTest
 
 
 	private testmethod static void testPicklistRollupWithLimits()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
@@ -1384,7 +1384,7 @@ private with sharing class RollupServiceTest
 
 
 	private testmethod static void testLastRollupWithLimits()
-	{		
+	{
 		// Test supported?
 		if(!TestContext.isSupported())
 			return;
@@ -1448,7 +1448,7 @@ private with sharing class RollupServiceTest
 			return;
 
 		// Disable the Account trigger for this test, its carefully caluculated test actuals are thrown when this is enabled as well
-		TestContext.AccountTestTriggerEnabled = false;			
+		TestContext.AccountTestTriggerEnabled = false;
 
 		// Configure rollup
 		LookupRollupSummary__c rollupSummary = new LookupRollupSummary__c();
@@ -1463,7 +1463,7 @@ private with sharing class RollupServiceTest
 		rollupSummary.Active__c = true;
 		rollupSummary.CalculationMode__c = 'Realtime';
 		insert rollupSummary;
-		
+
 		// Test data
 		Integer numAccounts = 3;
 		Account parentAccount1 = new Account();
@@ -1474,13 +1474,13 @@ private with sharing class RollupServiceTest
 		parentAccount2.AnnualRevenue = 0;
 		Account parentAccount3 = new Account();
 		parentAccount3.Name = 'Parent Account 3';
-		parentAccount3.AnnualRevenue = 0;		
+		parentAccount3.AnnualRevenue = 0;
 		List<Account> parentAccounts = new List<Account> { parentAccount1, parentAccount2, parentAccount3 };
 		insert parentAccounts;
 
 		List<Decimal> oppAmounts = new List<Decimal> { 100, 200, 300, 400 };
 		Decimal expectedAnnualRevenue = 1000;
-		List<Opportunity> childOpportunities = new List<Opportunity>(); 		
+		List<Opportunity> childOpportunities = new List<Opportunity>();
 		for (Account acct :parentAccounts)
 		{
 			for(Decimal oppAmount :oppAmounts)
@@ -1491,8 +1491,8 @@ private with sharing class RollupServiceTest
 				opp.CloseDate = System.today();
 				opp.AccountId = acct.Id;
 				opp.Amount = oppAmount;
-				childOpportunities.add(opp);			
-			}			
+				childOpportunities.add(opp);
+			}
 		}
 		insert childOpportunities;
 
@@ -1523,14 +1523,14 @@ private with sharing class RollupServiceTest
 		Integer beforeRows = Limits.getQueryRows();
 		Integer beforeDMLRows = Limits.getDMLRows();
 
-		// Update opportunities (1 record has change to field being aggregated, all others do not have changes to that field)		
+		// Update opportunities (1 record has change to field being aggregated, all others do not have changes to that field)
 		update oppsToModify;
 
 		// Assert limits
 		// + One query on Rollup object
-		// + One query on Opportunity for rollup	
-		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
-		
+		// + One query on Opportunity for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());
+
 		// + One row for Rollup object
 		// + Four rows for Opportunity on Parent 1
 		System.assertEquals(beforeRows + 5, Limits.getQueryRows());
@@ -1542,7 +1542,7 @@ private with sharing class RollupServiceTest
 		// assert rollups produced correct result
 		System.assertEquals(expectedAnnualRevenue + 1, [select AnnualRevenue from Account where Id = :parentAccount1.Id].AnnualRevenue);
 		System.assertEquals(expectedAnnualRevenue, [select AnnualRevenue from Account where Id = :parentAccount2.Id].AnnualRevenue);
-		System.assertEquals(expectedAnnualRevenue, [select AnnualRevenue from Account where Id = :parentAccount3.Id].AnnualRevenue);		
+		System.assertEquals(expectedAnnualRevenue, [select AnnualRevenue from Account where Id = :parentAccount3.Id].AnnualRevenue);
 	}
 
 	private testmethod static void testLimitsConsumedWithReparentOnly()
@@ -1584,11 +1584,11 @@ private with sharing class RollupServiceTest
 		rollupSummaryB.AggregateOperation__c = RollupSummaries.AggregateOperation.Sum.name();
 		rollupSummaryB.AggregateResultField__c = aggregateResultField2;
 		rollupSummaryB.Active__c = true;
-		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();		
+		rollupSummaryB.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
 
 		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummaryA, rollupSummaryB };
 		insert rollups;
-		
+
 		// Insert parents
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
@@ -1609,7 +1609,7 @@ private with sharing class RollupServiceTest
 		child2.put(relationshipField1, parentA.Id);
 		child2.put(relationshipField2, parentB.Id);
 		child2.put(aggregateField1, 'Yellow');
-		child2.put(aggregateField2, 22);		
+		child2.put(aggregateField2, 22);
 
 		List<SObject> children = new List<SObject> { child1, child2 };
 		insert children;
@@ -1638,16 +1638,16 @@ private with sharing class RollupServiceTest
 
 		// Assert limits
 		// + One query on Rollup object
-		// + One query on LookupChild__c for rollup	
-		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
-		
+		// + One query on LookupChild__c for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());
+
 		// + Two rows for Rollup object
 		// + Two rows for LookupChild__c for rollup B (One on Parent B and One on Parent C)
 		System.assertEquals(beforeRows + 4, Limits.getQueryRows());
 
 		// + Two rows for LookupChild__c (from the update statement itself)
 		// + Two rows for LookupParent__c (One for B and One for C)
-		System.assertEquals(beforeDMLRows + 4, Limits.getDMLRows());		
+		System.assertEquals(beforeDMLRows + 4, Limits.getDMLRows());
 
 		// Assert rollups
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0}, {1} from {2}', new List<String>{ aggregateResultField1, aggregateResultField2, parentObjectName })));
@@ -1659,7 +1659,7 @@ private with sharing class RollupServiceTest
 
 		System.assertEquals(null, (String) assertParents.get(parentC.id).get(aggregateResultField1));
 		System.assertEquals(20, (Decimal) assertParents.get(parentC.id).get(aggregateResultField2));
-	}	
+	}
 
     private static void assertOrdering(Utilities.Ordering o, String orderBy, Boolean useAsSpecifiedString, String field, Utilities.SortOrder direction, Boolean nullsLast)
     {
@@ -1669,7 +1669,8 @@ private with sharing class RollupServiceTest
         System.assertEquals(nullsLast, o.getNullsLast());
     }
 
-    static testMethod void testOrderingStringification()
+    @IsTest
+	static void testOrderingStringification()
     {
         Utilities.Ordering o = new Utilities.Ordering('CloseDate');
         assertOrdering(o, 'CloseDate ASC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
@@ -1693,16 +1694,16 @@ private with sharing class RollupServiceTest
         assertOrdering(o, 'CloseDate ASC NULLS LAST', false,'CloseDate', Utilities.SortOrder.ASCENDING, true);
 
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING, false);
-        assertOrdering(o, 'CloseDate ASC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, false);        
+        assertOrdering(o, 'CloseDate ASC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
 
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING, true);
-        assertOrdering(o, 'CloseDate ASC NULLS LAST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, true);        
+        assertOrdering(o, 'CloseDate ASC NULLS LAST', false, 'CloseDate', Utilities.SortOrder.ASCENDING, true);
 
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, false);
-        assertOrdering(o, 'CloseDate DESC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.DESCENDING, false);        
+        assertOrdering(o, 'CloseDate DESC NULLS FIRST', false, 'CloseDate', Utilities.SortOrder.DESCENDING, false);
 
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, true);
-        assertOrdering(o, 'CloseDate DESC NULLS LAST', false, 'CloseDate', Utilities.SortOrder.DESCENDING, true);        
+        assertOrdering(o, 'CloseDate DESC NULLS LAST', false, 'CloseDate', Utilities.SortOrder.DESCENDING, true);
 
          try {
             o = new Utilities.Ordering(null);
@@ -1710,10 +1711,11 @@ private with sharing class RollupServiceTest
          }
          catch (Utilities.BadOrderingStateException e) {
             System.assertEquals('field cannot be blank.', e.getMessage());
-         }        
+         }
     }
 
-    static testMethod void testOrderingAsSpecifiedStringification()
+    @IsTest
+	static void testOrderingAsSpecifiedStringification()
     {
         Utilities.Ordering o = new Utilities.Ordering('CloseDate');
         assertOrdering(o, 'CloseDate', true, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
@@ -1737,17 +1739,17 @@ private with sharing class RollupServiceTest
         assertOrdering(o, 'CloseDate NULLS LAST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, true);
 
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING, false);
-        assertOrdering(o, 'CloseDate ASC NULLS FIRST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, false);        
+        assertOrdering(o, 'CloseDate ASC NULLS FIRST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, false);
 
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.ASCENDING, true);
-        assertOrdering(o, 'CloseDate ASC NULLS LAST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, true);        
+        assertOrdering(o, 'CloseDate ASC NULLS LAST', true, 'CloseDate', Utilities.SortOrder.ASCENDING, true);
 
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, false);
-        assertOrdering(o, 'CloseDate DESC NULLS FIRST', true, 'CloseDate', Utilities.SortOrder.DESCENDING, false);        
+        assertOrdering(o, 'CloseDate DESC NULLS FIRST', true, 'CloseDate', Utilities.SortOrder.DESCENDING, false);
 
         o = new Utilities.Ordering('CloseDate', Utilities.SortOrder.DESCENDING, true);
-        assertOrdering(o, 'CloseDate DESC NULLS LAST', true, 'CloseDate', Utilities.SortOrder.DESCENDING, true);      
-    }  	
+        assertOrdering(o, 'CloseDate DESC NULLS LAST', true, 'CloseDate', Utilities.SortOrder.DESCENDING, true);
+    }
 
 	private testmethod static void testSingleQueryBasedRollupUpdateOrderByFieldChanged()
 	{
@@ -1776,11 +1778,11 @@ private with sharing class RollupServiceTest
 		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.ConcatenateDelimiter__c = ';';
 		rollupSummary.Active__c = true;
-		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();	
+		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
 
 		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummary };
 		insert rollups;
-		
+
 		// Insert parents
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
@@ -1811,7 +1813,7 @@ private with sharing class RollupServiceTest
 			child3.put(orderByField, 30);
 			children.add(child3);
 		}
-		insert children;		
+		insert children;
 
 		// Assert rollups
 		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
@@ -1821,7 +1823,7 @@ private with sharing class RollupServiceTest
 
 		// change Amount__c to effect order by result of rollup
 		// this change will result in rollup being processed because it is a query based rollup
-		// and order by influences rolled up value	
+		// and order by influences rolled up value
 		List<SObject> childrenToUpdate = new List<SObject>();
 		for (SObject child :children)
 		{
@@ -1842,16 +1844,16 @@ private with sharing class RollupServiceTest
 
 		// Assert limits
 		// + One query on Rollup object
-		// + One query on LookupChild__c for rollup	
-		System.assertEquals(beforeQueries + 2, Limits.getQueries());	
-		
+		// + One query on LookupChild__c for rollup
+		System.assertEquals(beforeQueries + 2, Limits.getQueries());
+
 		// + One row for Rollup object
 		// + Nine rows for LookupChild__c for rollup
 		System.assertEquals(beforeRows + 10, Limits.getQueryRows());
 
 		// + Three rows for LookupChild__c (from the update statement itself)
 		// + Three rows for LookupParent__c for the rollup
-		System.assertEquals(beforeDMLRows + 6, Limits.getDMLRows());		
+		System.assertEquals(beforeDMLRows + 6, Limits.getDMLRows());
 
 		// Assert rollups
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
@@ -1887,11 +1889,11 @@ private with sharing class RollupServiceTest
 		rollupSummary.AggregateResultField__c = aggregateResultField;
 		rollupSummary.ConcatenateDelimiter__c = ';';
 		rollupSummary.Active__c = true;
-		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();	
+		rollupSummary.CalculationMode__c = RollupSummaries.CalculationMode.Realtime.name();
 
 		List<LookupRollupSummary__c> rollups = new List<LookupRollupSummary__c> { rollupSummary };
 		insert rollups;
-		
+
 		// Insert parents
 		SObject parentA = parentType.newSObject();
 		parentA.put('Name', 'ParentA');
@@ -1922,7 +1924,7 @@ private with sharing class RollupServiceTest
 			child3.put(orderByField, 'Blue');
 			children.add(child3);
 		}
-		insert children;		
+		insert children;
 
 		// Assert rollups
 		Map<Id, SObject> assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));
@@ -1954,15 +1956,15 @@ private with sharing class RollupServiceTest
 		// Assert limits
 		// + One query on Rollup object
 		// No query on LookupChild__c because the changed Color__c should not be considered a change that would trigger the rollup to be processed
-		System.assertEquals(beforeQueries + 1, Limits.getQueries());	
-		
+		System.assertEquals(beforeQueries + 1, Limits.getQueries());
+
 		// + One row for Rollup object
-		// No rows on LookupChild__c because the changed Color__c should not be considered a change that would trigger the rollup to be processed		
+		// No rows on LookupChild__c because the changed Color__c should not be considered a change that would trigger the rollup to be processed
 		System.assertEquals(beforeRows + 1, Limits.getQueryRows());
 
 		// + Three rows for LookupChild__c (from the update statement itself)
-		// No query on LookupParent__c because the changed Color__c should not be considered a change that would trigger the rollup to be processed		
-		System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());		
+		// No query on LookupParent__c because the changed Color__c should not be considered a change that would trigger the rollup to be processed
+		System.assertEquals(beforeDMLRows + 3, Limits.getDMLRows());
 
 		// Assert rollups
 		assertParents = new Map<Id, SObject>(Database.query(String.format('select id, {0} from {1}', new List<String>{ aggregateResultField, parentObjectName })));

--- a/force-app/main/classes/RollupServiceTest.cls
+++ b/force-app/main/classes/RollupServiceTest.cls
@@ -1972,4 +1972,15 @@ private with sharing class RollupServiceTest
 		System.assertEquals(42, (Decimal) assertParents.get(parentB.id).get(aggregateResultField));
 		System.assertEquals(42, (Decimal) assertParents.get(parentC.id).get(aggregateResultField));
 	}
+
+	@IsTest
+	static void testExceptionThrowing()
+	{
+		try {
+			RollupService.throwServiceException(StatusCode.STORAGE_LIMIT_EXCEEDED, 'LookupName');
+			System.assert(false);
+		} catch (RollupServiceException e) {
+			System.assert(true);
+		}
+	}
 }


### PR DESCRIPTION
These changes should fix issue #794, providing a more meaningful message when we face a storage limit exception. This also allows for more DmlExceptions to be handled, but as far as I know most of them are impossible to mock in a test (like the storage exception itself).