### PR TITLE
Fix failing builds and replace deprecated org preferences

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 - sfdx force:auth:jwt:grant --clientid $CONSUMERKEY --jwtkeyfile assets/server.key --username $USERNAME --setdefaultdevhubusername -a HubOrg
 
 script:
-- sfdx force:org:create -v HubOrg -s -f config/project-scratch-def.json -a ciorg --wait 2
+- sfdx force:org:create -v HubOrg -s -f config/project-scratch-def.json -a ciorg --wait 5
 - sfdx force:org:display -u ciorg
 - sfdx force:source:push -u ciorg
 - sfdx force:apex:test:run -u ciorg --wait 10

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,7 +1,9 @@
 {
     "orgName": "andrewfawcett Company",
     "edition": "Developer",
-    "orgPreferences" : {
-        "enabled": ["S1DesktopEnabled"]
+    "settings": {
+        "orgPreferenceSettings": {
+            "s1DesktopEnabled": true
+        }
     }
 }


### PR DESCRIPTION
- Builds were failing due to 'force:org:create' command no longer accepting wait times of less than 5 seconds. 

- Org preferences have been replaced with scratch org settings and are deprecated starting with Winter'20. 