### PR TITLE
init pmd ruleset

### DIFF
--- a/apex-ruleset.xml
+++ b/apex-ruleset.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+<ruleset name="Custom Rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+        Apex all except Style
+    </description>
+
+    <rule ref="category/apex/performance.xml" />
+    <rule ref="category/apex/security.xml" />
+
+</ruleset>


### PR DESCRIPTION
Overrides PMD default to only include performance and security rules from https://github.com/pmd/pmd/tree/master/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule